### PR TITLE
Remove unused Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
----
-language: ruby
-cache: bundler
-rvm:
-  - 2.5.7
-before_install: gem install bundler -v 2.1.4


### PR DESCRIPTION
We are using Github Actions for CI, not Travis.

Fixes #9