### PR TITLE
Optimization for methods with no arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ TODO: Write usage instructions here
 
 |Gem|Method with no arguments|Method with positional arguments|Method with keyword arguments|
 |---|------------------------|--------------------------------|-----------------------------|
-|**`memo_wise`**|**11.90x (± 0.00) slower**|**baseline**|**baseline**|
-|`memery`|10.25x (± 0.00) slower|1.30x (± 0.00) slower|1.40x (± 0.00) slower|
-|`memoist`|2.26x (± 0.00) slower|1.47x (± 0.00) slower|1.52x (± 0.00) slower|
-|`memoized`|baseline|1.19x (± 0.00) slower|1.33x (± 0.00) slower|
-|`memoizer`|2.77x (± 0.00) slower|1.23x (± 0.00) slower|1.40x (± 0.00) slower|
+|**`memo_wise`**|**baseline**|**baseline**|**baseline**|
+|`memery`|13.02x (± 0.00) slower|1.27x (± 0.00) slower|1.49x (± 0.00) slower|
+|`memoist`|2.65x (± 0.00) slower|1.46x (± 0.00) slower|1.57x (± 0.00) slower|
+|`memoized`|1.27x  (± 0.00) slower|1.16x (± 0.00) slower|1.37x (± 0.00) slower|
+|`memoizer`|3.18x (± 0.00) slower|1.25x (± 0.00) slower|1.45x (± 0.00) slower|
 
 You can run benchmarks yourself with:
 

--- a/benchmarks/Gemfile
+++ b/benchmarks/Gemfile
@@ -7,7 +7,7 @@ ruby "2.7.1"
 
 gem "benchmark-ips"
 gem "memery"
-gem "memo_wise", path: ".."
 gem "memoist"
 gem "memoized"
 gem "memoizer"
+gem "memo_wise", path: ".."

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -33,17 +33,29 @@ module MemoWise
         alias_method not_memoized_name, method_name
         private not_memoized_name
 
-        module_eval <<-END_OF_METHOD, __FILE__, __LINE__ + 1
-          def #{method_name}(*args)
-            key = [:#{method_name}, args].freeze
-            @_memo_wise.fetch(key) do
-              @_memo_wise_keys[:#{method_name}] << args
-              @_memo_wise[key] = #{not_memoized_name}(*args)
+        if instance_method(method_name).arity.zero?
+          module_eval <<-END_OF_METHOD, __FILE__, __LINE__ + 1
+            def #{method_name}
+              @_memo_wise.fetch(:#{method_name}) do
+                @_memo_wise[:#{method_name}] = #{not_memoized_name}
+              end
             end
-          end
+          END_OF_METHOD
+        else
+          module_eval <<-END_OF_METHOD, __FILE__, __LINE__ + 1
+            def #{method_name}(*args)
+              key = [:#{method_name}, args].freeze
+              @_memo_wise.fetch(key) do
+                @_memo_wise_keys[:#{method_name}] << args
+                @_memo_wise[key] = #{not_memoized_name}(*args)
+              end
+            end
+          END_OF_METHOD
+        end
 
-          #{method_visibility} :#{method_name}
-        END_OF_METHOD
+        module_eval <<-END_OF_VISIBILITY, __FILE__, __LINE__ + 1
+          "#{method_visibility} :#{method_name}"
+        END_OF_VISIBILITY
       end
     end
   end
@@ -54,13 +66,14 @@ module MemoWise
     end
 
     unless respond_to?(method_name)
-      raise ArgumentError, "#{method_name.inspect} is not a defined method"
+      raise ArgumentError, "#{method_name} is not a defined method"
     end
 
     @_memo_wise_keys[method_name].each do |args|
       @_memo_wise.delete([method_name, args])
     end
 
+    @_memo_wise.delete(method_name)
     @_memo_wise_keys.delete(method_name)
   end
 


### PR DESCRIPTION
Going to wait for benchmarking to merge before making claims on hard numbers here, but checking out the `first-benchmarks` branch, it looks like this doesn't have a negative effect on any methods with arguments, and speeds up the no args case to only ~2x the best gem we're comparing against.