### PR TITLE
Implements #reset_memo_wise

### DIFF
--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -5,6 +5,7 @@ require "memo_wise/version"
 module MemoWise
   def initialize(*values)
     @_memo_wise = {}
+    @_memo_wise_keys = Hash.new { |h, k| h[k] = [] }
     super
   end
 
@@ -36,6 +37,7 @@ module MemoWise
           def #{method_name}(*args)
             key = [:#{method_name}, args].freeze
             @_memo_wise.fetch(key) do
+              @_memo_wise_keys[:#{method_name}] << args
               @_memo_wise[key] = #{not_memoized_name}(*args)
             end
           end
@@ -44,5 +46,17 @@ module MemoWise
         END_OF_METHOD
       end
     end
+  end
+
+  def reset_memo_wise(method_name)
+    unless respond_to?(method_name)
+      raise ArgumentError, "#{method_name.inspect} is not a defined method"
+    end
+
+    @_memo_wise_keys[method_name].each do |args|
+      @_memo_wise.delete([method_name, args])
+    end
+
+    @_memo_wise_keys.delete(method_name)
   end
 end

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -59,4 +59,9 @@ module MemoWise
 
     @_memo_wise_keys.delete(method_name)
   end
+
+  def reset_all_memo_wise
+    @_memo_wise_keys.clear
+    @_memo_wise.clear
+  end
 end

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -49,6 +49,10 @@ module MemoWise
   end
 
   def reset_memo_wise(method_name)
+    unless method_name.is_a?(Symbol)
+      raise ArgumentError, "#{method_name.inspect} must be a Symbol"
+    end
+
     unless respond_to?(method_name)
       raise ArgumentError, "#{method_name.inspect} is not a defined method"
     end

--- a/spec/memo_wise_spec.rb
+++ b/spec/memo_wise_spec.rb
@@ -240,6 +240,13 @@ RSpec.describe MemoWise do
       expect(instance2.no_args_counter).to eq(1)
     end
 
+    context "when the name of the method is not a symbol" do
+      it {
+        expect { instance.reset_memo_wise("no_args") }.
+          to raise_error(ArgumentError)
+      }
+    end
+
     context "when the method to reset memoization for is not defined" do
       it {
         expect { instance.reset_memo_wise(:not_defined) }.


### PR DESCRIPTION
This PR implements resetting of memoization. Once a method has already been memoized, it allows us to reset any memoized values while still leaving the method itself memoized.

Outside of the scope of this PR (but to come in later PR)
- YARDocs to describe this method