### PR TITLE
Allow passing arguments to reset_memo_wise

### DIFF
--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -60,7 +60,7 @@ module MemoWise
     end
   end
 
-  def reset_memo_wise(method_name)
+  def reset_memo_wise(method_name, *args)
     unless method_name.is_a?(Symbol)
       raise ArgumentError, "#{method_name.inspect} must be a Symbol"
     end
@@ -69,7 +69,11 @@ module MemoWise
       raise ArgumentError, "#{method_name} is not a defined method"
     end
 
-    @_memo_wise_keys[method_name].each do |args|
+    if args.empty?
+      @_memo_wise_keys[method_name].each do |method_args|
+        @_memo_wise.delete([method_name, method_args])
+      end
+    else
       @_memo_wise.delete([method_name, args])
     end
 

--- a/spec/memo_wise_spec.rb
+++ b/spec/memo_wise_spec.rb
@@ -188,6 +188,22 @@ RSpec.describe MemoWise do
       expect(instance.with_positional_args_counter).to eq(4)
     end
 
+    it "resets memoization for methods for specific positional arguments" do
+      instance.with_positional_args(1, 2)
+      instance.with_positional_args(2, 3)
+      instance.reset_memo_wise(:with_positional_args, 1, 2)
+
+      expect(Array.new(4) { instance.with_positional_args(1, 2) }).
+        to all eq("with_positional_args: a=1, b=2")
+
+      expect(Array.new(4) { instance.with_positional_args(2, 3) }).
+        to all eq("with_positional_args: a=2, b=3")
+
+      # This should be executed twice for each set of arguments passed,
+      # and a third time for the set of arguments that was reset.
+      expect(instance.with_positional_args_counter).to eq(3)
+    end
+
     it "resets memoization for methods with keyword arguments" do
       instance.with_keyword_args(a: 1, b: 2)
       instance.with_keyword_args(a: 2, b: 3)
@@ -201,6 +217,22 @@ RSpec.describe MemoWise do
 
       # This should be executed twice for each set of arguments passed
       expect(instance.with_keyword_args_counter).to eq(4)
+    end
+
+    it "resets memoization for methods for specific keyword arguments" do
+      instance.with_keyword_args(a: 1, b: 2)
+      instance.with_keyword_args(a: 2, b: 3)
+      instance.reset_memo_wise(:with_keyword_args, a: 1, b: 2)
+
+      expect(Array.new(4) { instance.with_keyword_args(a: 1, b: 2) }).
+        to all eq("with_keyword_args: a=1, b=2")
+
+      expect(Array.new(4) { instance.with_keyword_args(a: 2, b: 3) }).
+        to all eq("with_keyword_args: a=2, b=3")
+
+      # This should be executed twice for each set of arguments passed,
+      # and a third time for the set of arguments that was reset.
+      expect(instance.with_keyword_args_counter).to eq(3)
     end
 
     it "resets memoization for methods with special characters in the name" do


### PR DESCRIPTION
This commit provides the ability to pass arguments to reset_memo_wise

Thanks to @jsartin513 for pairing!