### PR TITLE
Reduce potential noise from benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ TODO: Write usage instructions here
 
 ## Benchmarks
 
-Using Ruby 2.7.1 and
+Memoized value retrieval time using Ruby 2.7.1 and
 [`benchmark-ips`](https://github.com/evanphx/benchmark-ips) 2.8.2:
 
 |Gem|Method with no arguments|Method with positional arguments|Method with keyword arguments|
 |---|------------------------|--------------------------------|-----------------------------|
 |**`memo_wise` (0.1.0)**|**baseline**|**baseline**|**baseline**|
-|`memery` (1.3.0)|13.99x (± 0.00) slower|1.23x (± 0.00) slower|1.45x (± 0.00) slower|
-|`memoist` (0.16.2)|2.77x (± 0.00) slower|1.37x (± 0.00) slower|1.52x (± 0.00) slower|
-|`memoized` (1.0.2)|1.26x  (± 0.00) slower|1.10x (± 0.00) slower|1.38x (± 0.00) slower|
-|`memoizer` (1.0.3)|3.24x (± 0.00) slower|1.23x (± 0.00) slower|1.45x (± 0.00) slower|
+|`memery` (1.3.0)|12.22x (± 0.00) slower|1.28x (± 0.00) slower|1.48x (± 0.00) slower|
+|`memoist` (0.16.2)|2.50x (± 0.00) slower|1.44x (± 0.00) slower|1.61x (± 0.00) slower|
+|`memoized` (1.0.2)|1.21x  (± 0.00) slower|1.17x (± 0.00) slower|1.40x (± 0.00) slower|
+|`memoizer` (1.0.3)|3.34x (± 0.00) slower|1.29x (± 0.00) slower|1.48x (± 0.00) slower|
 
 You can run benchmarks yourself with:
 


### PR DESCRIPTION
This commit changes the benchmarks to solely test memoized
value retrieval. All other costs (instance initialization,
memoized value storage) are removed from benchmarking to
limit ourselves to just what we care about optimizing the
most.

**Before merging:**

- [x] Copy the latest benchmark results into the `README.md` and update this PR
