### PR TITLE
Generate YARD docs locally

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gems-
     - run: bundle config path vendor/bundle
+    - run: bundle config set without 'linters'
+      if: matrix.ruby != 2.7
     - run: bundle install --jobs 4 --retry 3
     - run: bundle exec rspec
     - run: bundle exec rubocop

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,6 @@
+--readme README.md
+--title 'MemoWise Documentation'
+--charset utf-8
+--markup markdown
+'lib/**/*.rb' - '*.md'
+LICENSE.txt

--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,16 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
 group :test do
-  if RUBY_VERSION.start_with?("2.7")
-    # Match only Ruby version we run the linters on in CI
-    gem "panolint", github: "panorama-ed/panolint"
-  end
   gem "rspec", "~> 3.0"
   gem "values", "~> 1"
+end
+
+# Excluded from CI except on latest MRI Ruby, to reduce compatibility burden
+group :linters do
+  gem "panolint", github: "panorama-ed/panolint"
+end
+
+# Install locally to iterate on YARD docs and see them rendered
+group :docs, optional: true do
+  gem "yard", "~> 0.9"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
     values (1.8.0)
+    yard (0.9.25)
     zeitwerk (2.4.0)
 
 PLATFORMS
@@ -86,6 +87,7 @@ DEPENDENCIES
   panolint!
   rspec (~> 3.0)
   values (~> 1)
+  yard (~> 0.9)
 
 BUNDLED WITH
    2.1.4

--- a/README.md
+++ b/README.md
@@ -66,13 +66,29 @@ release a new version, update the version number in `version.rb`, and then run
 git commits and tags, and push the `.gem` file to
 [rubygems.org](https://rubygems.org).
 
+## Documentation
+
+We maintain API documentation using [YARD](https://yardoc.org/), which is
+published automatically at
+[RubyDoc.info](https://rubydoc.info/github/panorama-ed/memo_wise/main).
+
+To edit documentation locally and see it rendered in your browser, run:
+
+```bash
+bundle config set with 'docs'
+bundle install
+bundle exec yard server
+```
+
+And then open in your web browser: `http://localhost:8808`, refreshing to see
+your latest saved documentation changes rendered.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at
 https://github.com/panorama-ed/memo_wise. This project is intended to be a safe,
 welcoming space for collaboration, and contributors are expected to adhere to
 the [code of conduct](https://github.com/panorama-ed/memo_wise/blob/main/CODE_OF_CONDUCT.md).
-
 
 ## License
 


### PR DESCRIPTION
Run 'bundle exec yard server' to run a local server to
iterate on documentation and see the results in a browser.


