### PR TITLE
Install gem panolint only on Ruby 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,10 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
 group :test do
-  gem "panolint", github: "panorama-ed/panolint"
+  if RUBY_VERSION.start_with?("2.7")
+    # Match only Ruby version we run the linters on in CI
+    gem "panolint", github: "panorama-ed/panolint"
+  end
   gem "rspec", "~> 3.0"
   gem "values", "~> 1"
 end


### PR DESCRIPTION
We only run linters in CI on Ruby 2.7, and the dependencies
of the panolint gem have broken (hopefully temporarily) on
JRuby now.

We'd like to match our CI build dependencies up with the tests
that we run, so that we don't get test failures from dependency
incompatibilities with Ruby versions that we won't be running them
on.


