### PR TITLE
Backfill initial yard docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,11 +20,13 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gems-
     - run: bundle config path vendor/bundle
-    - run: bundle config set without 'linters'
+    - run: bundle config set without 'linters:docs'
       if: matrix.ruby != 2.7
     - run: bundle install --jobs 4 --retry 3
     - run: bundle exec rspec
     - run: bundle exec rubocop
+      if: matrix.ruby == 2.7
+    - run: bundle exec yard doctest
       if: matrix.ruby == 2.7
     - run: |
         BUNDLE_GEMFILE=benchmarks/Gemfile bundle install --jobs 4 --retry 3

--- a/.yardopts
+++ b/.yardopts
@@ -2,5 +2,7 @@
 --title 'MemoWise Documentation'
 --charset utf-8
 --markup markdown
+--plugin yard-doctest
+--no-private
 'lib/**/*.rb' - '*.md'
 LICENSE.txt

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,9 @@ group :linters do
   gem "panolint", github: "panorama-ed/panolint"
 end
 
-# Install locally to iterate on YARD docs and see them rendered
-group :docs, optional: true do
+# Excluded from CI except on latest MRI Ruby, to reduce compatibility burden
+group :docs do
+  gem "redcarpet", "~> 3.5"
   gem "yard", "~> 0.9"
+  gem "yard-doctest", "~> 0.1"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,7 @@ GEM
       ast (~> 2.4.1)
     rack (2.2.3)
     rainbow (3.0.0)
+    redcarpet (3.5.0)
     regexp_parser (1.8.1)
     rexml (3.2.4)
     rspec (3.9.0)
@@ -77,6 +78,9 @@ GEM
     unicode-display_width (1.7.0)
     values (1.8.0)
     yard (0.9.25)
+    yard-doctest (0.1.17)
+      minitest
+      yard
     zeitwerk (2.4.0)
 
 PLATFORMS
@@ -85,9 +89,11 @@ PLATFORMS
 DEPENDENCIES
   memo_wise!
   panolint!
+  redcarpet (~> 3.5)
   rspec (~> 3.0)
   values (~> 1)
   yard (~> 0.9)
+  yard-doctest (~> 0.1)
 
 BUNDLED WITH
    2.1.4

--- a/README.md
+++ b/README.md
@@ -68,20 +68,25 @@ git commits and tags, and push the `.gem` file to
 
 ## Documentation
 
+#### Documentation is Automatically Generated
+
 We maintain API documentation using [YARD](https://yardoc.org/), which is
 published automatically at
-[RubyDoc.info](https://rubydoc.info/github/panorama-ed/memo_wise/main).
-
-To edit documentation locally and see it rendered in your browser, run:
+[RubyDoc.info](https://rubydoc.info/github/panorama-ed/memo_wise/main). To edit
+documentation locally and see it rendered in your browser, run:
 
 ```bash
-bundle config set with 'docs'
-bundle install
 bundle exec yard server
 ```
 
-And then open in your web browser: `http://localhost:8808`, refreshing to see
-your latest saved documentation changes rendered.
+#### Documentation Examples are Automatically Tested
+
+We use [yard-doctest](https://github.com/p0deje/yard-doctest) to test all
+code examples in our YARD documentation. To run `doctest` locally:
+
+```bash
+bundle exec yard doctest
+```
 
 ## Contributing
 

--- a/benchmarks/Gemfile
+++ b/benchmarks/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 # Keep updated to latest Ruby, and keep in sync with benchmarks/.ruby-version.
-ruby "2.7.1"
+ruby "~> 2.7.1"
 
 gem "benchmark-ips", "2.8.2"
 gem "memery", "1.3.0"

--- a/spec/doctest_helper.rb
+++ b/spec/doctest_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# See: https://github.com/p0deje/yard-doctest
+
+require "memo_wise"

--- a/spec/memo_wise_spec.rb
+++ b/spec/memo_wise_spec.rb
@@ -326,206 +326,222 @@ RSpec.describe MemoWise do
   end
 
   describe "#reset_memo_wise" do
-    it "resets memoization for methods with no arguments" do
-      instance.no_args
-      instance.reset_memo_wise(:no_args)
-      expect(Array.new(4) { instance.no_args }).to all eq("no_args")
-      expect(instance.no_args_counter).to eq(2)
-    end
-
-    it "resets memoization for methods with positional arguments" do
-      instance.with_positional_args(1, 2)
-      instance.with_positional_args(2, 3)
-      instance.reset_memo_wise(:with_positional_args)
-
-      expect(Array.new(4) { instance.with_positional_args(1, 2) }).
-        to all eq("with_positional_args: a=1, b=2")
-
-      expect(Array.new(4) { instance.with_positional_args(1, 3) }).
-        to all eq("with_positional_args: a=1, b=3")
-
-      # This should be executed twice for each set of arguments passed
-      expect(instance.with_positional_args_counter).to eq(4)
-    end
-
-    it "resets memoization for methods for specific positional arguments" do
-      instance.with_positional_args(1, 2)
-      instance.with_positional_args(2, 3)
-      instance.reset_memo_wise(:with_positional_args, 1, 2)
-
-      expect(Array.new(4) { instance.with_positional_args(1, 2) }).
-        to all eq("with_positional_args: a=1, b=2")
-
-      expect(Array.new(4) { instance.with_positional_args(2, 3) }).
-        to all eq("with_positional_args: a=2, b=3")
-
-      # This should be executed twice for each set of arguments passed,
-      # and a third time for the set of arguments that was reset.
-      expect(instance.with_positional_args_counter).to eq(3)
-    end
-
-    it "resets memoization for methods with keyword arguments" do
-      instance.with_keyword_args(a: 1, b: 2)
-      instance.with_keyword_args(a: 2, b: 3)
-      instance.reset_memo_wise(:with_keyword_args)
-
-      expect(Array.new(4) { instance.with_keyword_args(a: 1, b: 2) }).
-        to all eq("with_keyword_args: a=1, b=2")
-
-      expect(Array.new(4) { instance.with_keyword_args(a: 2, b: 3) }).
-        to all eq("with_keyword_args: a=2, b=3")
-
-      # This should be executed twice for each set of arguments passed
-      expect(instance.with_keyword_args_counter).to eq(4)
-    end
-
-    it "resets memoization for methods for specific keyword arguments" do
-      instance.with_keyword_args(a: 1, b: 2)
-      instance.with_keyword_args(a: 2, b: 3)
-      instance.reset_memo_wise(:with_keyword_args, a: 1, b: 2)
-
-      expect(Array.new(4) { instance.with_keyword_args(a: 1, b: 2) }).
-        to all eq("with_keyword_args: a=1, b=2")
-
-      expect(Array.new(4) { instance.with_keyword_args(a: 2, b: 3) }).
-        to all eq("with_keyword_args: a=2, b=3")
-
-      # This should be executed twice for each set of arguments passed,
-      # and a third time for the set of arguments that was reset.
-      expect(instance.with_keyword_args_counter).to eq(3)
-    end
-
-    it "resets memoization for methods with special characters in the name" do
-      instance.special_chars?
-      instance.reset_memo_wise(:special_chars?)
-      expect(Array.new(4) { instance.special_chars? }).
-        to all eq("special_chars?")
-      expect(instance.special_chars_counter).to eq(2)
-    end
-
-    it "resets memoization for methods set to false values" do
-      instance.false_method
-      instance.reset_memo_wise(:false_method)
-      expect(Array.new(4) { instance.false_method }).to all eq(false)
-      expect(instance.false_method_counter).to eq(2)
-    end
-
-    it "resets memoization for methods set to nil values" do
-      instance.nil_method
-      instance.reset_memo_wise(:nil_method)
-      expect(Array.new(4) { instance.nil_method }).to all eq(nil)
-      expect(instance.nil_method_counter).to eq(2)
-    end
-
-    it "does not reset memoization methods across instances" do
-      instance2 = class_with_memo.new
-
-      instance.no_args
-      instance2.no_args
-
-      instance.reset_memo_wise(:no_args)
-
-      instance.no_args
-      instance2.no_args
-
-      expect(instance.no_args_counter).to eq(2)
-      expect(instance2.no_args_counter).to eq(1)
-    end
-
-    context "when the name of the method is not a symbol" do
-      it do
-        expect { instance.reset_memo_wise("no_args") }.
-          to raise_error(ArgumentError)
-      end
-    end
-
-    context "when the method to reset memoization for is not memoized" do
-      it do
-        expect { instance.reset_memo_wise(:unmemoized_method) { nil } }.
-          to raise_error(ArgumentError)
-      end
-    end
-
-    context "when the method to reset memoization for is not defined" do
-      it do
-        expect { instance.reset_memo_wise(:not_defined) }.
-          to raise_error(ArgumentError)
-      end
-    end
-  end
-
-  describe "#reset_all_memo_wise" do
-    let!(:instance) do
-      class_with_memo.new.tap do |instance|
+    context "when method_name is given" do
+      it "resets memoization for methods with no arguments" do
         instance.no_args
+        instance.reset_memo_wise(:no_args)
+        expect(Array.new(4) { instance.no_args }).to all eq("no_args")
+        expect(instance.no_args_counter).to eq(2)
+      end
+
+      it "resets memoization for methods with positional arguments" do
         instance.with_positional_args(1, 2)
         instance.with_positional_args(2, 3)
+        instance.reset_memo_wise(:with_positional_args)
+
+        expect(Array.new(4) { instance.with_positional_args(1, 2) }).
+          to all eq("with_positional_args: a=1, b=2")
+
+        expect(Array.new(4) { instance.with_positional_args(1, 3) }).
+          to all eq("with_positional_args: a=1, b=3")
+
+        # This should be executed twice for each set of arguments passed
+        expect(instance.with_positional_args_counter).to eq(4)
+      end
+
+      it "resets memoization for methods for specific positional arguments" do
+        instance.with_positional_args(1, 2)
+        instance.with_positional_args(2, 3)
+        instance.reset_memo_wise(:with_positional_args, 1, 2)
+
+        expect(Array.new(4) { instance.with_positional_args(1, 2) }).
+          to all eq("with_positional_args: a=1, b=2")
+
+        expect(Array.new(4) { instance.with_positional_args(2, 3) }).
+          to all eq("with_positional_args: a=2, b=3")
+
+        # This should be executed twice for each set of arguments passed,
+        # and a third time for the set of arguments that was reset.
+        expect(instance.with_positional_args_counter).to eq(3)
+      end
+
+      it "resets memoization for methods with keyword arguments" do
         instance.with_keyword_args(a: 1, b: 2)
         instance.with_keyword_args(a: 2, b: 3)
-        instance.special_chars?
-        instance.false_method
-        instance.nil_method
+        instance.reset_memo_wise(:with_keyword_args)
 
-        instance.reset_all_memo_wise
+        expect(Array.new(4) { instance.with_keyword_args(a: 1, b: 2) }).
+          to all eq("with_keyword_args: a=1, b=2")
+
+        expect(Array.new(4) { instance.with_keyword_args(a: 2, b: 3) }).
+          to all eq("with_keyword_args: a=2, b=3")
+
+        # This should be executed twice for each set of arguments passed
+        expect(instance.with_keyword_args_counter).to eq(4)
+      end
+
+      it "resets memoization for methods for specific keyword arguments" do
+        instance.with_keyword_args(a: 1, b: 2)
+        instance.with_keyword_args(a: 2, b: 3)
+        instance.reset_memo_wise(:with_keyword_args, a: 1, b: 2)
+
+        expect(Array.new(4) { instance.with_keyword_args(a: 1, b: 2) }).
+          to all eq("with_keyword_args: a=1, b=2")
+
+        expect(Array.new(4) { instance.with_keyword_args(a: 2, b: 3) }).
+          to all eq("with_keyword_args: a=2, b=3")
+
+        # This should be executed twice for each set of arguments passed,
+        # and a third time for the set of arguments that was reset.
+        expect(instance.with_keyword_args_counter).to eq(3)
+      end
+
+      it "resets memoization for methods with special characters in the name" do
+        instance.special_chars?
+        instance.reset_memo_wise(:special_chars?)
+        expect(Array.new(4) { instance.special_chars? }).
+          to all eq("special_chars?")
+        expect(instance.special_chars_counter).to eq(2)
+      end
+
+      it "resets memoization for methods set to false values" do
+        instance.false_method
+        instance.reset_memo_wise(:false_method)
+        expect(Array.new(4) { instance.false_method }).to all eq(false)
+        expect(instance.false_method_counter).to eq(2)
+      end
+
+      it "resets memoization for methods set to nil values" do
+        instance.nil_method
+        instance.reset_memo_wise(:nil_method)
+        expect(Array.new(4) { instance.nil_method }).to all eq(nil)
+        expect(instance.nil_method_counter).to eq(2)
+      end
+
+      it "does not reset memoization methods across instances" do
+        instance2 = class_with_memo.new
+
+        instance.no_args
+        instance2.no_args
+
+        instance.reset_memo_wise(:no_args)
+
+        instance.no_args
+        instance2.no_args
+
+        expect(instance.no_args_counter).to eq(2)
+        expect(instance2.no_args_counter).to eq(1)
+      end
+
+      context "when the name of the method is not a symbol" do
+        it do
+          expect { instance.reset_memo_wise("no_args") }.
+            to raise_error(ArgumentError)
+        end
+      end
+
+      context "when the method to reset memoization for is not memoized" do
+        it do
+          expect { instance.reset_memo_wise(:unmemoized_method) { nil } }.
+            to raise_error(ArgumentError)
+        end
+      end
+
+      context "when the method to reset memoization for is not defined" do
+        it do
+          expect { instance.reset_memo_wise(:not_defined) }.
+            to raise_error(ArgumentError)
+        end
       end
     end
 
-    it "resets memoization for methods with no arguments" do
-      expect(Array.new(4) { instance.no_args }).to all eq("no_args")
-      expect(instance.no_args_counter).to eq(2)
-    end
+    context "when method_name is *not* given (e.g. 'reset all' mode)" do
+      let!(:instance) do
+        class_with_memo.new.tap do |instance|
+          instance.no_args
+          instance.with_positional_args(1, 2)
+          instance.with_positional_args(2, 3)
+          instance.with_keyword_args(a: 1, b: 2)
+          instance.with_keyword_args(a: 2, b: 3)
+          instance.special_chars?
+          instance.false_method
+          instance.nil_method
 
-    it "resets memoization for methods with positional arguments" do
-      expect(Array.new(4) { instance.with_positional_args(1, 2) }).
-        to all eq("with_positional_args: a=1, b=2")
+          instance.reset_memo_wise
+        end
+      end
 
-      expect(Array.new(4) { instance.with_positional_args(1, 3) }).
-        to all eq("with_positional_args: a=1, b=3")
+      it "resets memoization for methods with no arguments" do
+        expect(Array.new(4) { instance.no_args }).to all eq("no_args")
+        expect(instance.no_args_counter).to eq(2)
+      end
 
-      # This should be executed twice for each set of arguments passed
-      expect(instance.with_positional_args_counter).to eq(4)
-    end
+      it "resets memoization for methods with positional arguments" do
+        expect(Array.new(4) { instance.with_positional_args(1, 2) }).
+          to all eq("with_positional_args: a=1, b=2")
 
-    it "resets memoization for methods with keyword arguments" do
-      expect(Array.new(4) { instance.with_keyword_args(a: 1, b: 2) }).
-        to all eq("with_keyword_args: a=1, b=2")
+        expect(Array.new(4) { instance.with_positional_args(1, 3) }).
+          to all eq("with_positional_args: a=1, b=3")
 
-      expect(Array.new(4) { instance.with_keyword_args(a: 2, b: 3) }).
-        to all eq("with_keyword_args: a=2, b=3")
+        # This should be executed twice for each set of arguments passed
+        expect(instance.with_positional_args_counter).to eq(4)
+      end
 
-      # This should be executed twice for each set of arguments passed
-      expect(instance.with_keyword_args_counter).to eq(4)
-    end
+      it "resets memoization for methods with keyword arguments" do
+        expect(Array.new(4) { instance.with_keyword_args(a: 1, b: 2) }).
+          to all eq("with_keyword_args: a=1, b=2")
 
-    it "resets memoization for methods with special characters in the name" do
-      expect(Array.new(4) { instance.special_chars? }).
-        to all eq("special_chars?")
-      expect(instance.special_chars_counter).to eq(2)
-    end
+        expect(Array.new(4) { instance.with_keyword_args(a: 2, b: 3) }).
+          to all eq("with_keyword_args: a=2, b=3")
 
-    it "resets memoization for methods set to false values" do
-      expect(Array.new(4) { instance.false_method }).to all eq(false)
-      expect(instance.false_method_counter).to eq(2)
-    end
+        # This should be executed twice for each set of arguments passed
+        expect(instance.with_keyword_args_counter).to eq(4)
+      end
 
-    it "resets memoization for methods set to nil values" do
-      expect(Array.new(4) { instance.nil_method }).to all eq(nil)
-      expect(instance.nil_method_counter).to eq(2)
-    end
+      it "resets memoization for methods with special characters in the name" do
+        expect(Array.new(4) { instance.special_chars? }).
+          to all eq("special_chars?")
+        expect(instance.special_chars_counter).to eq(2)
+      end
 
-    it "does not reset memoization methods across instances" do
-      instance2 = class_with_memo.new
+      it "resets memoization for methods set to false values" do
+        expect(Array.new(4) { instance.false_method }).to all eq(false)
+        expect(instance.false_method_counter).to eq(2)
+      end
 
-      instance.no_args
-      instance2.no_args
+      it "resets memoization for methods set to nil values" do
+        expect(Array.new(4) { instance.nil_method }).to all eq(nil)
+        expect(instance.nil_method_counter).to eq(2)
+      end
 
-      instance.reset_all_memo_wise
+      it "does not reset memoization methods across instances" do
+        instance2 = class_with_memo.new
 
-      instance.no_args
-      instance2.no_args
+        instance.no_args
+        instance2.no_args
 
-      expect(instance.no_args_counter).to eq(3)
-      expect(instance2.no_args_counter).to eq(1)
+        instance.reset_memo_wise
+
+        instance.no_args
+        instance2.no_args
+
+        expect(instance.no_args_counter).to eq(3)
+        expect(instance2.no_args_counter).to eq(1)
+      end
+
+      context "when method_name=nil and args given" do
+        it do
+          expect { instance.reset_memo_wise(nil, 42) { nil } }.
+            to raise_error(ArgumentError)
+        end
+      end
+
+      context "when method_name=nil and kwargs given" do
+        it do
+          expect { instance.reset_memo_wise(foo: 42) { nil } }.
+            to raise_error(ArgumentError)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
First pass through the MemoWise module. Includes all of the non-metaprogrammed class and instance methods. Excludes all of the meta-programmed methods, which will come in a separate PR after we figure out the best way to document them.

We add examples in the YARD doc comments which are tested using the
`yard doctest` plugin.