### PR TITLE
Backfill metaprogrammed methods YARD docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@
 [![Gem Version](https://img.shields.io/gem/v/memo_wise.svg)](https://rubygems.org/gems/memo_wise)
 [![Gem Downloads](https://img.shields.io/gem/dt/memo_wise.svg)](https://rubygems.org/gems/memo_wise)
 
-TODO: Write clear description of MemoWise
+## Why MemoWise?
+
+**MemoWise is the wise choice for memoization in Ruby.**
+
+  * Fast performance of memoized reads (see [Benchmarks](#benchmarks))
+  * Support for memoization on frozen objects
+  * Support for memoization of class and module methods (COMING SOON!)
+  * Full documentation and test coverage!
 
 ## Installation
 
@@ -26,7 +33,24 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+```ruby
+class Example
+  prepend MemoWise
+
+  def method_to_memoize(x)
+    @method_called_times = (@method_called_times || 0) + 1
+  end
+  memo_wise :method_to_memoize
+end
+
+ex = Example.new
+
+ex.method_to_memoize("a") #=> 1
+ex.method_to_memoize("a") #=> 1
+
+ex.method_to_memoize("b") #=> 2
+ex.method_to_memoize("b") #=> 2
+```
 
 ## Benchmarks
 

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -3,6 +3,22 @@
 require "memo_wise/version"
 
 # MemoWise is the wise choice for memoization in Ruby.
+#
+# - **Q:** What is *memoization*?
+# - **A:** [via Wikipedia](https://en.wikipedia.org/wiki/Memoization):
+#
+#          [Memoization is] an optimization technique used primarily to speed up
+#          computer programs by storing the results of expensive function
+#          calls and returning the cached result when the same inputs occur
+#          again.
+#
+# To start using MemoWise in a class or module:
+#
+#   1. Add `prepend MemoWise` to the top of the class or module
+#   2. Call {.memo_wise} to implement memoization for a given method
+#
+# @see .memo_wise
+#
 module MemoWise # rubocop:disable Metrics/ModuleLength
   # Constructor to setup memoization state before
   # [calling the original](https://medium.com/@jeremy_96642/ruby-method-auditing-using-module-prepend-4f4e69aacd95)
@@ -111,10 +127,7 @@ module MemoWise # rubocop:disable Metrics/ModuleLength
   #
   def self.prepended(target) # rubocop:disable Metrics/PerceivedComplexity
     class << target
-      # Implements memoization for the given method name.
-      #
-      # @param method_name [Symbol]
-      #   Name of method for which to implement memoization.
+      # NOTE: See YARD docs for {.memo_wise} directly below this method!
       def memo_wise(method_name) # rubocop:disable Metrics/PerceivedComplexity
         unless method_name.is_a?(Symbol)
           raise ArgumentError,
@@ -182,6 +195,41 @@ module MemoWise # rubocop:disable Metrics/ModuleLength
       end
     end
   end
+
+  ##
+  # @!method self.memo_wise(method_name)
+  #   Implements memoization for the given method name.
+  #
+  #   - **Q:** What does it mean to "implement memoization"?
+  #   - **A:** To wrap the original method such that, for any given set of
+  #            arguments, the original method will be called at most *once*. The
+  #            result of that call will be stored on the object. All future
+  #            calls to the same method with the same set of arguments will then
+  #            return that saved result.
+  #
+  #   @param method_name [Symbol]
+  #     Name of method for which to implement memoization.
+  #
+  #   @return [void]
+  #
+  #   @example
+  #     class Example
+  #       prepend MemoWise
+  #
+  #       def method_to_memoize(x)
+  #         @method_called_times = (@method_called_times || 0) + 1
+  #       end
+  #       memo_wise :method_to_memoize
+  #     end
+  #
+  #     ex = Example.new
+  #
+  #     ex.method_to_memoize("a") #=> 1
+  #     ex.method_to_memoize("a") #=> 1
+  #
+  #     ex.method_to_memoize("b") #=> 2
+  #     ex.method_to_memoize("b") #=> 2
+  ##
 
   # Presets the memoized result for the given method to the result of the given
   # block.


### PR DESCRIPTION
This PR uses the YARD `@!method` tag to document the class method that is created in `.prepended` -- the actual `.memo_wise` method!