### PR TITLE
Add CodeCov badge and minimum coverages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![Inline docs](http://inch-ci.org/github/panorama-ed/memo_wise.svg?branch=main)](http://inch-ci.org/github/panorama-ed/memo_wise)
 [![Gem Version](https://img.shields.io/gem/v/memo_wise.svg)](https://rubygems.org/gems/memo_wise)
 [![Gem Downloads](https://img.shields.io/gem/dt/memo_wise.svg)](https://rubygems.org/gems/memo_wise)
+[![Code Coverage](https://codecov.io/gh/panorama-ed/memo_wise/branch/main/graph/badge.svg)](https://codecov.io/gh/panorama-ed/memo_wise)
+
 
 ## Why MemoWise?
 

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -189,9 +189,7 @@ module MemoWise # rubocop:disable Metrics/ModuleLength
           END_OF_METHOD
         end
 
-        module_eval <<-END_OF_VISIBILITY, __FILE__, __LINE__ + 1
-          "#{method_visibility} :#{method_name}"
-        END_OF_VISIBILITY
+        module_eval "#{method_visibility} :#{method_name}", __FILE__, __LINE__
       end
     end
   end

--- a/spec/memo_wise_spec.rb
+++ b/spec/memo_wise_spec.rb
@@ -115,15 +115,15 @@ RSpec.describe MemoWise do
         @private_memowise_method_counter += 1
         "private_memowise_method"
       end
-      memo_wise :private_memowise_method
       private :private_memowise_method
+      memo_wise :private_memowise_method
 
       def protected_memowise_method
         @protected_memowise_method_counter += 1
         "protected_memowise_method"
       end
-      memo_wise :protected_memowise_method
       protected :protected_memowise_method
+      memo_wise :protected_memowise_method
 
       def public_memowise_method
         @public_memowise_method_counter += 1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,30 @@
 # frozen_string_literal: true
 
+# Simplecov needs to be loaded before we require `memo_wise` in order to
+# properly track all memo_wise files
+if Gem.loaded_specs.key?("codecov")
+  require "codecov"
+  require "simplecov"
+
+  SimpleCov.start do
+    enable_coverage :branch
+  end
+
+  SimpleCov.formatter = if ENV["CI"] == "true"
+                          SimpleCov::Formatter::Codecov
+                        else
+                          # Writes coverage file into coverage/index.html
+                          # when run outside of CI for local development
+                          SimpleCov::Formatter::HTMLFormatter
+                        end
+
+  # SimpleCov.refuse_coverage_drop is only implemented for line coverage, so for
+  # branch coverage we must use `minimum_coverage`
+  SimpleCov.minimum_coverage branch: 90
+
+  SimpleCov.refuse_coverage_drop
+end
+
 require "bundler/setup"
 require "memo_wise"
 
@@ -13,14 +38,4 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
-end
-
-if ENV["CI"] == "true" && Gem.loaded_specs.key?("codecov")
-  require "codecov"
-  require "simplecov"
-
-  SimpleCov.start do
-    enable_coverage :branch
-  end
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end


### PR DESCRIPTION
This PR:
* Adds CodeCov badge
* Adds `lib/memo_wise.rb` to the files evaluated by CodeCov
* Fixes private / protected memoization to improve CodeCov results
* Fails the test suite when line coverage lowers, or branch coverage falls below 90%

Resolves Issue #59 