### PR TITLE
Fix configuration for Dependabot v1

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -8,6 +8,6 @@ update_configs:
       - match:
           dependency_type: "development"
           update_type: "all"
-- package_manager: "ruby:bundler"
+  - package_manager: "ruby:bundler"
     directory: "/benchmarks"
     update_schedule: "live"


### PR DESCRIPTION
Fixes #22

Tested this with the online YAML parser linked from #22.

**Before merging:**

- [ ] ~Copy the latest benchmark results into the `README.md` and update this PR~

**After merging:**

- [ ] Ensure that Dependabot runs