### PR TITLE
Add support for Class method memoization

### DIFF
--- a/spec/memo_wise_spec.rb
+++ b/spec/memo_wise_spec.rb
@@ -289,6 +289,82 @@ RSpec.describe MemoWise do
       expect(instance2.no_args_counter).to eq(0)
     end
 
+    context "when memo_wise has *not* been called on a *class* method" do
+      it "does *not* create class-level instance variable" do
+        expect(class_with_memo.instance_variables).not_to include(:@_memo_wise)
+      end
+    end
+
+    context "with class methods" do
+      context "when defined with 'def self.'" do
+        let(:class_with_memo) do
+          Class.new do
+            prepend MemoWise
+
+            def self.class_method_counter
+              @class_method_counter || 0
+            end
+
+            def self.self_dot_method(a, b: "default") # rubocop:disable Naming/MethodParameterName
+              @class_method_counter = class_method_counter + 1
+              "self_dot_method: a=#{a}, b=#{b}"
+            end
+            memo_wise :self_dot_method
+          end
+        end
+
+        it "memoizes class methods defined with 'def self.'" do
+          expect(Array.new(4) { class_with_memo.self_dot_method(1, b: 2) }).
+            to all eq("self_dot_method: a=1, b=2")
+
+          expect(Array.new(4) { class_with_memo.self_dot_method(1, b: 3) }).
+            to all eq("self_dot_method: a=1, b=3")
+
+          expect(class_with_memo.class_method_counter).to eq(2)
+        end
+
+        it "creates a class-level instance variable" do
+          # NOTE: test implementation detail to ensure the inverse test is valid
+          expect(class_with_memo.instance_variables).to include(:@_memo_wise)
+        end
+      end
+
+      context "when defined with scope 'class << self'" do
+        let(:class_with_memo) do
+          Class.new do
+            class << self
+              prepend MemoWise
+
+              def class_method_counter
+                @class_method_counter || 0
+              end
+
+              def class_self_method(a, b: "default") # rubocop:disable Naming/MethodParameterName
+                @class_method_counter = class_method_counter + 1
+                "class_self_method: a=#{a}, b=#{b}"
+              end
+              memo_wise :class_self_method
+            end
+          end
+        end
+
+        it "memoizes class methods defined with scope 'class << self'" do
+          expect(Array.new(4) { class_with_memo.class_self_method(1, b: 2) }).
+            to all eq("class_self_method: a=1, b=2")
+
+          expect(Array.new(4) { class_with_memo.class_self_method(1, b: 3) }).
+            to all eq("class_self_method: a=1, b=3")
+
+          expect(class_with_memo.class_method_counter).to eq(2)
+        end
+
+        it "creates a class-level instance variable" do
+          # NOTE: this test ensure the inverse test above continues to be valid
+          expect(class_with_memo.instance_variables).to include(:@_memo_wise)
+        end
+      end
+    end
+
     context "with private methods" do
       it "keeps private methods private" do
         expect(instance.private_methods).to include(:private_memowise_method)
@@ -782,6 +858,76 @@ RSpec.describe MemoWise do
       it do
         expect { instance.preset_memo_wise(:no_args) }.
           to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe "private APIs" do
+    describe ".method_info" do
+      subject { described_class.method_info(klass, :method_name) }
+
+      context "when klass is neither Class nor Module" do
+        let(:klass) { "not a class" }
+
+        it { expect { subject }.to raise_error(ArgumentError) }
+      end
+    end
+
+    describe ".method_visibility" do
+      subject { described_class.method_visibility(String, method_name) }
+
+      context "when method_name not a method on klass" do
+        let(:method_name) { :not_a_method }
+
+        it { expect { subject }.to raise_error(ArgumentError) }
+      end
+    end
+
+    describe ".original_class_from_singleton" do
+      subject { described_class.original_class_from_singleton(klass) }
+
+      context "when klass is not a singleton class" do
+        let(:klass) { String }
+
+        it { expect { subject }.to raise_error(ArgumentError) }
+      end
+
+      context "when klass is a singleton class of an original class" do
+        let(:klass) { original_class.singleton_class }
+
+        context "when assigned to a constant (normal case)" do
+          let(:original_class) { String }
+
+          it { is_expected.to eq(original_class) }
+        end
+
+        context "when not assigned to a constant (anonymous case)" do
+          let(:original_class) { class_with_memo }
+
+          it { is_expected.to eq(original_class) }
+
+          context "when singleton class #to_s convention not followed" do
+            let(:klass) do
+              super().tap do |sc|
+                sc.define_singleton_method(:to_s) { "not following convention" }
+              end
+            end
+
+            it { is_expected.to eq(original_class) }
+          end
+        end
+      end
+    end
+
+    describe ".create_memo_wise_state!" do
+      subject { described_class.create_memo_wise_state!(obj) }
+
+      context "when obj already has instance variable '@_memo_wise'" do
+        let(:obj) do
+          Object.new.tap { |o| o.instance_variable_set(:@_memo_wise, 42) }
+        end
+
+        it { expect { subject }.to raise_error(ArgumentError) }
       end
     end
   end


### PR DESCRIPTION
Included in this PR is support for memoization of class methods,
which in Ruby are technically instance methods of the singleton
class.

Support class methods defined in two ways.

(1) The "self." syntax:

    class SelfDot
      prepend MemoWise

      def self.foo; end
      memo_wise :foo
    end

(2) The "class << self" syntax:

    class ClassShiftSelf
      class << self
        prepend MemoWise

        def foo; end
        memo_wise :foo
      end
    end

Planned future PRs:

  (A) Enhance README and Documentation to show class methods

  (B) Refactor the tests into examples that can all be run for all of:
       - instance methods
       - class methods defined first way
       - class methods defined second way

  (C) Refactor the code to extract all meta-programming and reflection
      concerns to utility classes and document and test them independently;
      Leave core 'memo_wise' easier to read

**Before merging:**

- [ ] add a new commit updating the benchmarks with results from GitHub Actions