### PR TITLE
Removes raising error when memoizing methods which take block args

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ Memoized value retrieval time using Ruby 2.7.2 and
 
 |Method arguments|**`memo_wise` (0.1.0)**|`memery` (1.3.0)|`memoist` (0.16.2)|`memoized` (1.0.2)|`memoizer` (1.0.3)|
 |--|--|--|--|--|--|
-|`()` (none)|**baseline**|12.27x slower|2.57x slower|1.22x slower|3.22x slower|
-|`(a, b)`|**baseline**|2.00x slower|2.21x slower|1.80x slower|2.01x slower|
-|`(a:, b:)`|**baseline**|2.29x slower|2.41x slower|2.16x slower|2.28x slower|
-|`(a, b:)`|**baseline**|1.58x slower|1.71x slower|1.49x slower|1.56x slower|
-|`(a, *args)`|**baseline**|2.03x slower|2.30x slower|1.95x slower|2.01x slower|
-|`(a:, **kwargs)`|**baseline**|1.94x slower|2.08x slower|1.88x slower|1.90x slower|
-|`(a, *args, b:, **kwargs)`|**baseline**|1.97x slower|2.18x slower|1.91x slower|1.93x slower|
+|`()` (none)|**baseline**|12.18x slower|2.47x slower|1.20x slower|3.11x slower|
+|`(a, b)`|**baseline**|2.01x slower|2.24x slower|1.80x slower|1.99x slower|
+|`(a:, b:)`|**baseline**|2.19x slower|2.34x slower|2.07x slower|2.18x slower|
+|`(a, b:)`|**baseline**|1.50x slower|1.62x slower|1.42x slower|1.49x slower|
+|`(a, *args)`|**baseline**|2.03x slower|2.29x slower|1.95x slower|2.01x slower|
+|`(a:, **kwargs)`|**baseline**|1.89x slower|2.02x slower|1.87x slower|1.89x slower|
+|`(a, *args, b:, **kwargs)`|**baseline**|1.95x slower|2.15x slower|1.91x slower|1.93x slower|
 
 Benchmarks are run in GitHub Actions and updated in every PR that changes code.
 

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -116,38 +116,6 @@ module MemoWise # rubocop:disable Metrics/ModuleLength
 
   # @private
   #
-  # Determine whether `method` takes a *block* arg.
-  #
-  # There is one type of block arg:
-  #
-  #   * *Block* -- ex: `def foo(&block)`
-  #
-  # @param method [Method, UnboundMethod]
-  #   Arguments of this method will be checked
-  #
-  # @return [Boolean]
-  #   Return `true` if `method` accepts a block argument
-  #
-  # @example
-  #   class Example
-  #     def position_args(a, b=1)
-  #     end
-  #
-  #     def block_args(&block)
-  #       block.call
-  #     end
-  #   end
-  #
-  #   MemoWise.has_block_arg?(Example.instance_method(:position_args)) #=> false
-  #
-  #   MemoWise.has_block_arg?(Example.instance_method(:block_args)) #=> true
-  #
-  def self.has_block_arg?(method) # rubocop:disable Naming/PredicateName
-    method.parameters.last&.first == :block
-  end
-
-  # @private
-  #
   # Returns visibility of an instance method defined on a class.
   #
   # @param klass [Class]
@@ -295,11 +263,6 @@ module MemoWise # rubocop:disable Metrics/ModuleLength
         original_memo_wised_name = :"_memo_wise_original_#{method_name}"
         klass.send(:alias_method, original_memo_wised_name, method_name)
         klass.send(:private, original_memo_wised_name)
-
-        if MemoWise.has_block_arg?(method)
-          raise ArgumentError,
-                "Methods which take block arguments cannot be memoized"
-        end
 
         # Zero-arg methods can use simpler/more performant logic because the
         # hash key is just the method name.

--- a/spec/memo_wise_spec.rb
+++ b/spec/memo_wise_spec.rb
@@ -173,7 +173,10 @@ RSpec.describe MemoWise do
       end
       memo_wise :proc_method
 
-      def explicit_block_method(&block); end
+      def explicit_block_method(&block) # rubocop:disable Lint/UnusedMethodArgument
+        yield
+      end
+      memo_wise :explicit_block_method
 
       def implicit_block_method
         yield
@@ -580,11 +583,8 @@ RSpec.describe MemoWise do
     end
 
     it "will not memoize methods with explicit block arguments" do
-      expect { instance.class.memo_wise(:explicit_block_method) }.
-        to raise_error(
-          ArgumentError,
-          "Methods which take block arguments cannot be memoized"
-        )
+      expect { instance.explicit_block_method { nil  } }.
+        to raise_error(LocalJumpError)
     end
 
     context "with class methods with same name as memoized instance methods" do


### PR DESCRIPTION
This PR no longer raises an error when methods which take explicit block args are memoized. 

**Before merging:**

- [ ] Copy the latest benchmark results into the `README.md` and update this PR
- [ ] If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)