### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/benchmarks/.bundle/
 /.yardoc
 /_yardoc/
 /coverage/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    memo_wise (0.1.0)
+    memo_wise (0.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/benchmarks/Gemfile.lock
+++ b/benchmarks/Gemfile.lock
@@ -1,0 +1,26 @@
+PATH
+  remote: ..
+  specs:
+    memo_wise (0.3.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    benchmark-ips (2.8.4)
+    memery (1.3.0)
+      ruby2_keywords (~> 0.0.2)
+    ruby2_keywords (0.0.4)
+
+PLATFORMS
+  x86_64-darwin-19
+
+DEPENDENCIES
+  benchmark-ips (= 2.8.4)
+  memery (= 1.3.0)
+  memo_wise!
+
+RUBY VERSION
+   ruby 3.0.0p0
+
+BUNDLED WITH
+   2.2.3

--- a/lib/memo_wise/version.rb
+++ b/lib/memo_wise/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MemoWise
-  VERSION = "0.1.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
I'll also rebase this one after the previous two PRs are merged.

This is the archetypal final PR before running `rake release`, which does nothing other than officially bumping the version number.

In case you are wondering "when do we create a git tag?", actually the rake task will do that for us.