### PR TITLE
Fix dependabot errors due to panolint branch name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ end
 # Excluded from CI except on latest MRI Ruby, to reduce compatibility burden
 group :checks do
   gem "codecov"
-  gem "panolint", github: "panorama-ed/panolint"
+  gem "panolint", github: "panorama-ed/panolint", branch: "main"
 end
 
 # Excluded from CI except on latest MRI Ruby, to reduce compatibility burden

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/panorama-ed/panolint.git
-  revision: ca5edaa1f6985e2812998a937229f972c07bce56
+  revision: 4b39e31ffd8ca41acbe2ba11a768f9342b9b5227
+  branch: main
   specs:
     panolint (0.1.2)
       brakeman (>= 4.8, < 6.0)
@@ -18,11 +19,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.4.4)
+    activesupport (6.1.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     ast (2.4.2)
     brakeman (5.0.0)
     codecov (0.5.1)
@@ -30,9 +32,9 @@ GEM
     concurrent-ruby (1.1.8)
     diff-lcs (1.4.4)
     docile (1.3.5)
-    i18n (1.8.8)
+    i18n (1.8.9)
       concurrent-ruby (~> 1.0)
-    minitest (5.14.3)
+    minitest (5.14.4)
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)
@@ -40,7 +42,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.3)
     redcarpet (3.5.1)
-    regexp_parser (2.0.3)
+    regexp_parser (2.1.1)
     rexml (3.2.4)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -55,7 +57,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.0)
-    rubocop (1.9.1)
+    rubocop (1.11.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -66,7 +68,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
-    rubocop-performance (1.9.2)
+    rubocop-performance (1.10.1)
       rubocop (>= 0.90.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     rubocop-rails (2.9.1)
@@ -83,15 +85,15 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
-    thread_safe (0.3.6)
-    tzinfo (1.2.9)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.0.0)
     values (1.8.0)
     yard (0.9.26)
     yard-doctest (0.1.17)
       minitest
       yard
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Add 'branch: main' to Gemfile for the gem panolint, and run
'bundle update panolint'.

See #119
