### PR TITLE
Allow keyword arguments in initializers when including MemoWise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Documentation of confusing module test behavior
+- Allow including MemoWise in classes with keyword arguments in the initializer
 
 ## [0.3.0] - 2021-02-11
 ### Added

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -2,6 +2,14 @@
 
 require "memo_wise/version"
 
+# This is required to shim keyword argument handling for backwards compatibility
+# for ruby versions before 2.7.
+#
+# See https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
+# for more information.
+def ruby2_keywords(*)
+end if RUBY_VERSION < "2.7"
+
 # MemoWise is the wise choice for memoization in Ruby.
 #
 # - **Q:** What is *memoization*?
@@ -39,7 +47,7 @@ module MemoWise # rubocop:disable Metrics/ModuleLength
   # [Values](https://github.com/tcrayford/Values)
   # [gem](https://rubygems.org/gems/values).
   #
-  def initialize(*, **)
+  ruby2_keywords def initialize(*)
     MemoWise.create_memo_wise_state!(self)
     super
   end

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -41,12 +41,18 @@ module MemoWise # rubocop:disable Metrics/ModuleLength
   #
   # To support syntax differences with keyword and positional arguments starting
   # with ruby 2.7, we have to set up the initializer with some slightly
-  # different syntax for the different versions.
+  # different syntax for the different versions.  This variance in syntax is not
+  # included in coverage reports since the branch chosen will never differ
+  # within a single ruby version.  This means it is impossible for us to get
+  # 100% coverage of this line within a single CI run.
   #
   # See
   # [this article](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)
   # for more information.
+  #
+  # :nocov:
   all_args = RUBY_VERSION < "2.7" ? "*" : "..."
+  # :nocov:
   class_eval <<-END_OF_METHOD
     def initialize(#{all_args})
       MemoWise.create_memo_wise_state!(self)

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -39,17 +39,20 @@ module MemoWise # rubocop:disable Metrics/ModuleLength
   # [Values](https://github.com/tcrayford/Values)
   # [gem](https://rubygems.org/gems/values).
   #
-  if RUBY_VERSION < "2.7"
-    def initialize(*, &block)
+  # To support syntax differences with keyword and positional arguments starting
+  # with ruby 2.7, we have to set up the initializer with some slightly
+  # different syntax for the different versions.
+  #
+  # See
+  # [this article](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)
+  # for more information.
+  all_args = RUBY_VERSION < "2.7" ? "*" : "..."
+  class_eval <<-END_OF_METHOD
+    def initialize(#{all_args})
       MemoWise.create_memo_wise_state!(self)
       super
     end
-  else
-    def initialize(*, **, &block)
-      MemoWise.create_memo_wise_state!(self)
-      super
-    end
-  end
+  END_OF_METHOD
 
   # @private
   #

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -2,14 +2,6 @@
 
 require "memo_wise/version"
 
-# This is required to shim keyword argument handling for backwards compatibility
-# for ruby versions before 2.7.
-#
-# See https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
-# for more information.
-def ruby2_keywords(*)
-end if RUBY_VERSION < "2.7"
-
 # MemoWise is the wise choice for memoization in Ruby.
 #
 # - **Q:** What is *memoization*?
@@ -47,9 +39,16 @@ module MemoWise # rubocop:disable Metrics/ModuleLength
   # [Values](https://github.com/tcrayford/Values)
   # [gem](https://rubygems.org/gems/values).
   #
-  ruby2_keywords def initialize(*)
-    MemoWise.create_memo_wise_state!(self)
-    super
+  if RUBY_VERSION < "2.7"
+    def initialize(*, &block)
+      MemoWise.create_memo_wise_state!(self)
+      super
+    end
+  else
+    def initialize(*, **, &block)
+      MemoWise.create_memo_wise_state!(self)
+      super
+    end
   end
 
   # @private

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -53,7 +53,7 @@ module MemoWise # rubocop:disable Metrics/ModuleLength
   # :nocov:
   all_args = RUBY_VERSION < "2.7" ? "*" : "..."
   # :nocov:
-  class_eval <<-END_OF_METHOD
+  class_eval <<-END_OF_METHOD, __FILE__, __LINE__ + 1
     # On Ruby 2.7 or greater:
     #
     # def initialize(...)

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -54,6 +54,20 @@ module MemoWise # rubocop:disable Metrics/ModuleLength
   all_args = RUBY_VERSION < "2.7" ? "*" : "..."
   # :nocov:
   class_eval <<-END_OF_METHOD
+    # On Ruby 2.7 or greater:
+    #
+    # def initialize(...)
+    #   MemoWise.create_memo_wise_state!(self)
+    #   super
+    # end
+    #
+    # On Ruby 2.6 or lower:
+    #
+    # def initialize(*)
+    #   MemoWise.create_memo_wise_state!(self)
+    #   super
+    # end
+
     def initialize(#{all_args})
       MemoWise.create_memo_wise_state!(self)
       super

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -39,7 +39,7 @@ module MemoWise # rubocop:disable Metrics/ModuleLength
   # [Values](https://github.com/tcrayford/Values)
   # [gem](https://rubygems.org/gems/values).
   #
-  def initialize(*)
+  def initialize(*, **)
     MemoWise.create_memo_wise_state!(self)
     super
   end

--- a/spec/memo_wise_spec.rb
+++ b/spec/memo_wise_spec.rb
@@ -595,6 +595,50 @@ RSpec.describe MemoWise do
         expect(class_with_memo.class_positional_args_counter).to eq(4)
       end
     end
+
+    context "when the class's initializer take arguments" do
+      context "when it only takes positional arguments" do
+        let(:class_with_memo) do
+          Class.new do
+            prepend MemoWise
+
+            def initialize(arg); end
+          end
+        end
+
+        it "does not raise an error when initializing the class" do
+          expect { class_with_memo.new(:pos) }.to_not raise_error
+        end
+      end
+
+      context "when it only takes keyword arguments" do
+        let(:class_with_memo) do
+          Class.new do
+            prepend MemoWise
+
+            def initialize(kwarg:); end
+          end
+        end
+
+        it "does not raise an error when initializing the class" do
+          expect { class_with_memo.new(kwarg: :kw) }.to_not raise_error
+        end
+      end
+
+      context "when it take both positional and keyword arguments" do
+        let(:class_with_memo) do
+          Class.new do
+            prepend MemoWise
+
+            def initialize(arg, kwarg:); end
+          end
+        end
+
+        it "does not raise an error when initializing the class" do
+          expect { class_with_memo.new(:pos, kwarg: :kw) }.to_not raise_error
+        end
+      end
+    end
   end
 
   describe "#reset_memo_wise" do

--- a/spec/memo_wise_spec.rb
+++ b/spec/memo_wise_spec.rb
@@ -638,6 +638,22 @@ RSpec.describe MemoWise do
           expect { class_with_memo.new(:pos, kwarg: :kw) }.to_not raise_error
         end
       end
+
+      context "when the method takes positional arguments, keyword arguments, "\
+              "and a block" do
+        let(:class_with_memo) do
+          Class.new do
+            prepend MemoWise
+
+            def initialize(arg, kwarg:, &block); end
+          end
+        end
+
+        it "does not raise an error when initializing the class" do
+          expect { class_with_memo.new(:pos, kwarg: :kw) { true } }.
+            to_not raise_error
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Currently on ruby 3.0, prepending MemoWise into a class which accepts keyword arguments
in its initializer causes an ArgumentError to be thrown:

ArgumentError (wrong number of arguments (given 1, expected 0; required keyword: :kwarg))

This change allows both positional and keyword arguments to initializers in classes which
use MemoWise.  This is compatible with versions before 3.0 as well.

**Before merging:**

- [ ] Copy the latest benchmark results into the `README.md` and update this PR
- [ ] If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)