### PR TITLE
Fix Marshal serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
 - Documentation of confusing module test behavior
-- Allow including MemoWise in classes with keyword arguments in the initializer
+- Support using MemoWise in classes with keyword arguments in the initializer
+- Support Marshal dump/load of classes using MemoWise
 
 ## [0.3.0] - 2021-02-11
 ### Added

--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ run in GitHub Actions and updated in every PR that changes code.
 
 |Method arguments|**`memo_wise` (0.1.0)**|`memery` (1.3.0)|`memoist`\* (0.16.2)|`memoized`\* (1.0.2)|`memoizer`\* (1.0.3)|
 |--|--|--|--|--|--|
-|`()` (none)|**baseline**|14.69x slower|2.59x slower|1.15x slower|2.91x slower|
-|`(a, b)`|**baseline**|1.93x slower|2.20x slower|1.79x slower|1.96x slower|
-|`(a:, b:)`|**baseline**|3.01x slower|2.41x slower|2.18x slower|2.28x slower|
-|`(a, b:)`|**baseline**|1.49x slower|1.75x slower|1.51x slower|1.60x slower|
-|`(a, *args)`|**baseline**|1.92x slower|2.23x slower|1.94x slower|1.98x slower|
-|`(a:, **kwargs)`|**baseline**|3.08x slower|2.48x slower|2.17x slower|2.28x slower|
-|`(a, *args, b:, **kwargs)`|**baseline**|1.55x slower|1.73x slower|1.65x slower|1.67x slower|
+|`()` (none)|**baseline**|13.17x slower|2.85x slower|1.30x slower|3.05x slower|
+|`(a, b)`|**baseline**|1.93x slower|2.20x slower|1.97x slower|1.86x slower|
+|`(a:, b:)`|**baseline**|3.05x slower|2.34x slower|2.27x slower|2.14x slower|
+|`(a, b:)`|**baseline**|1.50x slower|1.63x slower|1.56x slower|1.48x slower|
+|`(a, *args)`|**baseline**|1.91x slower|2.13x slower|1.90x slower|1.88x slower|
+|`(a:, **kwargs)`|**baseline**|3.08x slower|2.37x slower|2.24x slower|2.09x slower|
+|`(a, *args, b:, **kwargs)`|**baseline**|1.72x slower|1.61x slower|1.56x slower|1.67x slower|
 
 _\*Indicates a benchmark run on Ruby 2.7.2 because the gem raises errors in Ruby
 3.0.0 due to its incorrect handling of keyword arguments._

--- a/spec/memo_wise_spec.rb
+++ b/spec/memo_wise_spec.rb
@@ -574,6 +574,15 @@ RSpec.describe MemoWise do
           expect(instance2.no_args_counter).to eq(1)
         end
 
+        context "when args are given" do
+          context "when no value is memoized for the method" do
+            it "doesn't raise an error" do
+              expect { instance.reset_memo_wise(:with_positional_args, 1, 2) }.
+                not_to raise_error(NoMethodError)
+            end
+          end
+        end
+
         context "when the name of the method is not a symbol" do
           it do
             expect { instance.reset_memo_wise("no_args") }.
@@ -919,6 +928,50 @@ RSpec.describe MemoWise do
           expect { class_with_memo.new(:pos, kwarg: :kw) { true } }.
             to_not raise_error
         end
+      end
+    end
+
+    context "when serializing using Marshal" do
+      let(:class_with_memo) do
+        Class.new do
+          prepend MemoWise
+
+          attr_reader :name, :name_upper_counter
+
+          def initialize(name:)
+            @name = name
+            @name_upper_counter = 0
+          end
+
+          def name_upper
+            @name_upper_counter += 1
+            name.upcase
+          end
+          memo_wise :name_upper
+        end
+      end
+
+      before :each do
+        stub_const("ClassForTest", class_with_memo)
+      end
+
+      it "dumps and loads without error" do
+        obj1 = ClassForTest.new(name: "foo")
+        obj2 = Marshal.load(Marshal.dump(obj1))
+        expect(obj2.class).to be(ClassForTest)
+        expect(obj2.name).to eq(obj1.name)
+      end
+
+      it "dumps and loads memoized state" do
+        obj1 = ClassForTest.new(name: "foo")
+        obj1.name_upper
+        obj2 = Marshal.load(Marshal.dump(obj1))
+
+        expect { obj2.name_upper }.
+          not_to change { obj2.name_upper_counter }.
+          from(1)
+
+        expect(obj2.name_upper).to eq("FOO")
       end
     end
   end


### PR DESCRIPTION
As pointed out by @honigc in #137, the use of a default proc in the
core MemoWise Hash instance makes serialization using Marshal impossible.

This PR replaces the implementation with a simple Hash, and sets the
default values along the API code paths that previously relied on the
default value.

We cover the case in #reset_memo_wise where specific args are passed,
to avoid regression of a Nil error when attempting to reset args that
are not yet memoized, as this error would become possible now that
there is no default value proc in the Hash.

Closes #137

**Before merging:**

- [x] Copy the latest benchmark results into the `README.md` and update this PR
- [x] If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)