### PR TITLE
Use caching from ruby/setup-ruby github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,25 +15,30 @@ jobs:
         ruby: [jruby, 2.4, 2.5, 2.6, 2.7, 3.0]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v2
+
+    # Conditionally configure bundler via environment variables as advised
+    #   * https://github.com/ruby/setup-ruby#bundle-config
+    - name: Set bundler environment variables
+      run: |
+        echo "BUNDLE_WITHOUT=checks:docs" >> $GITHUB_ENV
+      if: matrix.ruby != 3.0
+
+    # Use 'bundler-cache: true' instead of actions/cache as advised:
+    #   * https://github.com/actions/cache/blob/main/examples.md#ruby---bundler
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
-    - run: bundle config path vendor/bundle
-    - run: bundle config set without 'checks:docs'
-      if: matrix.ruby != 3.0
-    - run: bundle install --jobs 4 --retry 3
+        bundler-cache: true
+
     - run: bundle exec rspec
+
     - run: bundle exec rubocop
       if: matrix.ruby == 3.0
+
     - run: bundle exec yard doctest
       if: matrix.ruby == 3.0
+
     - run: |
         BUNDLE_GEMFILE=benchmarks/Gemfile bundle install --jobs 4 --retry 3
         BUNDLE_GEMFILE=benchmarks/Gemfile bundle exec ruby benchmarks/benchmarks.rb

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,8 @@ jobs:
     - run: bundle exec yard doctest
       if: matrix.ruby == 3.0
 
-    - run: |
+    - name: Run benchmarks on Ruby 2.7 or 3.0
+      run: |
         BUNDLE_GEMFILE=benchmarks/Gemfile bundle install --jobs 4 --retry 3
         BUNDLE_GEMFILE=benchmarks/Gemfile bundle exec ruby benchmarks/benchmarks.rb
       if: matrix.ruby == '2.7' || matrix.ruby == '3.0'

--- a/README.md
+++ b/README.md
@@ -108,18 +108,6 @@ $ bundle exec ruby benchmarks.rb
 If your results differ from what's posted here,
 [let us know](https://github.com/panorama-ed/memo_wise/issues/new)!
 
-## Development
-
-After checking out the repo, run `bin/setup` to install dependencies. Then, run
-`rake spec` to run the tests. You can also run `bin/console` for an interactive
-prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To
-release a new version, update the version number in `version.rb`, and then run
-`bundle exec rake release`, which will create a git tag for the version, push
-git commits and tags, and push the `.gem` file to
-[rubygems.org](https://rubygems.org).
-
 ## Documentation
 
 ### Documentation is Automatically Generated
@@ -182,7 +170,7 @@ To make a new release of `MemoWise` to
 dependencies (e.g. `rake`) as follows:
 
 ```shell
-bundle config set --local with 'release'
+bundle config --local with 'release'
 bundle install
 ```
 


### PR DESCRIPTION
It is advised to use the 'bundler-cache: true' option
of the ruby/setup-ruby github instead of the actions/cache action:
  * https://github.com/ruby/setup-ruby#bundle-config

In this configuration, in order to set bundler config, it
is advised to set BUNDLE_* environment variables before the
ruby/setup-ruby action runs:
  * https://github.com/ruby/setup-ruby#bundle-config

To enable conditional setting of these environment variables, it
is advised to append to the $GITHUB_ENV file rather than using the
'env:' yaml section:
  * https://github.community/t/possible-to-use-conditional-in-the-env-section-of-a-job/135170
