### PR TITLE
Exclude 'specs' path from coverage

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ if Gem.loaded_specs.key?("codecov")
 
   SimpleCov.start do
     enable_coverage :branch
+    add_filter "/spec/"
   end
 
   SimpleCov.formatter = if ENV["CI"] == "true"


### PR DESCRIPTION
Configure SimpleCov to ignore the specs directory.

