### PR TITLE
Decorate .instance_method to proxy original params

### DIFF
--- a/spec/proxying_original_method_params_spec.rb
+++ b/spec/proxying_original_method_params_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe "proxying original method params" do # rubocop:disable RSpec/DescribeClass
+  describe ".instance_method" do
+    subject { unbound_method&.parameters }
+
+    let(:unbound_method) { class_with_memo.instance_method(method_name) }
+
+    let(:class_with_memo) do
+      Class.new do
+        prepend MemoWise
+
+        def initialize(foo, bar:); end
+
+        DefineMethodsForTestingMemoWise.define_methods_for_testing_memo_wise(
+          target: self,
+          via: :instance
+        )
+
+        def unmemoized_with_positional_and_keyword_args(a, b:) # rubocop:disable Naming/MethodParameterName
+          [a, b]
+        end
+      end
+    end
+
+    context "when #initialize" do
+      let(:method_name) { :initialize }
+      let(:expected_parameters) { [[:req, :foo], [:keyreq, :bar]] } # rubocop:disable Style/SymbolArray
+
+      it "returns expected parameters" do
+        is_expected.to eq(expected_parameters)
+      end
+
+      it "proxies UnboundMethod#parameters via singleton method" do
+        expect(unbound_method.singleton_methods).to eq [:parameters]
+      end
+    end
+
+    context "when #with_optional_positional_and_keyword_args" do
+      let(:method_name) { :with_optional_positional_and_keyword_args }
+      let(:expected_parameters) { [[:opt, :a], [:key, :b]] } # rubocop:disable Style/SymbolArray
+
+      it "returns expected parameters" do
+        is_expected.to eq(expected_parameters)
+      end
+
+      it "proxies UnboundMethod#parameters via singleton method" do
+        expect(unbound_method.singleton_methods).to eq [:parameters]
+      end
+    end
+
+    context "when #unmemoized_method" do
+      let(:method_name) { :unmemoized_method }
+      let(:expected_parameters) { [] }
+
+      it "returns expected parameters" do
+        is_expected.to eq(expected_parameters)
+      end
+
+      it "does *not* proxy UnboundMethod#parameters via singleton method" do
+        expect(unbound_method.singleton_methods).to eq []
+      end
+    end
+
+    context "when #unmemoized_with_positional_and_keyword_args" do
+      let(:method_name) { :unmemoized_with_positional_and_keyword_args }
+      let(:expected_parameters) { [[:req, :a], [:keyreq, :b]] } # rubocop:disable Style/SymbolArray
+
+      it "returns expected parameters" do
+        is_expected.to eq(expected_parameters)
+      end
+
+      it "does *not* proxy UnboundMethod#parameters via singleton method" do
+        expect(unbound_method.singleton_methods).to eq []
+      end
+    end
+
+    context "when method does *not* exist" do
+      let(:method_name) { :DOES_NOT_EXIST }
+
+      it "raises NameError" do
+        expect { subject }.to raise_error(
+          NameError,
+          /undefined method `DOES_NOT_EXIST' for class/
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
In Panorama spec helper code 'initialized_double', we observed
that MemoWise interrupts the use of Ruby reflection on method
parameters, by replacing with delegating methods that have overly
generic signatures, like:

    def initialize(...)

    def slow_method(*arg, **kwargs)

After investigation, we had determined that it was not worth
the complexity cost, and potential fragility, to pursue a solution
where we re-create the original method parmeter signatures for our
delegating implementations.

This PR is a minimalistic alternative, which narrowly overrides only
the implementation of {Module#instance_method} so that, in the case
of either #initialize or a method that has had .memo_wise called on it,
we look up the original method and proxy the original result value of
calling UnboundMethod#parameters on it.

