### PR TITLE
Add dry-core Memoizable to the benchmark

### DIFF
--- a/benchmarks/Gemfile
+++ b/benchmarks/Gemfile
@@ -7,6 +7,7 @@ ruby ">= 2.7.2"
 gem "benchmark-ips", "2.9.1"
 
 if RUBY_VERSION > "3"
+  gem "dry-core", "0.7.1"
   gem "memery", "1.4.0"
 else
   gem "ddmemoize", "1.0.0"

--- a/benchmarks/benchmarks.rb
+++ b/benchmarks/benchmarks.rb
@@ -6,12 +6,15 @@ require "memo_wise"
 
 # Some gems do not yet work in Ruby 3 so we only require them if they're loaded
 # in the Gemfile.
-%w[memery memoist memoized memoizer ddmemoize].
+%w[memery memoist memoized memoizer ddmemoize dry-core].
   each { |gem| require gem if Gem.loaded_specs.key?(gem) }
 
 # The VERSION constant does not get loaded above for these gems.
 %w[memoized memoizer].
   each { |gem| require "#{gem}/version" if Gem.loaded_specs.key?(gem) }
+
+# The Memoizable module from dry-core needs to be required manually
+require "dry/core/memoizable" if Gem.loaded_specs.key?("dry-core")
 
 class BenchmarkSuiteWithoutGC
   def warming(*)
@@ -49,11 +52,12 @@ end
 # rubocop:disable Layout/LineLength
 BENCHMARK_GEMS = [
   BenchmarkGem.new(MemoWise, "prepend MemoWise", :memo_wise),
+  (BenchmarkGem.new(DDMemoize, "DDMemoize.activate(self)", :memoize) if defined?(DDMemoize)),
+  (BenchmarkGem.new(Dry::Core, "include Dry::Core::Memoizable", :memoize) if defined?(Dry::Core)),
   (BenchmarkGem.new(Memery, "include Memery", :memoize) if defined?(Memery)),
   (BenchmarkGem.new(Memoist, "extend Memoist", :memoize) if defined?(Memoist)),
   (BenchmarkGem.new(Memoized, "include Memoized", :memoize) if defined?(Memoized)),
-  (BenchmarkGem.new(Memoizer, "include Memoizer", :memoize) if defined?(Memoizer)),
-  (BenchmarkGem.new(DDMemoize, "DDMemoize.activate(self)", :memoize) if defined?(DDMemoize))
+  (BenchmarkGem.new(Memoizer, "include Memoizer", :memoize) if defined?(Memoizer))
 ].compact.shuffle
 # rubocop:enable Layout/LineLength
 


### PR DESCRIPTION
Added the Memoizable module from [dry-core](https://github.com/dry-rb/dry-core) to the benchmark. The 0 and 1 argument benchmarks favour `memo_wise`, while `dry-core` is faster in the others.

I'm not exactly sure what the differences in implementation are. Maybe there is more optimization potential here, or maybe it is simply a matter of prioritizing a certain type of methods.

The table in README.md seems to assume that other gems always run slower, therefore I wasn't sure how to update it. Should the table be restructured somehow or should I calculate the numbers manually? (memo_wise 2x slower => dry-core 0.5x slower)

- [ ] Copy the latest benchmark results into the `README.md` and update this PR