### PR TITLE
Temporarily disable some tests for JRuby

### DIFF
--- a/spec/memo_wise/internal_api_spec.rb
+++ b/spec/memo_wise/internal_api_spec.rb
@@ -10,26 +10,31 @@ RSpec.describe MemoWise::InternalAPI do
       it { expect { subject }.to raise_error(ArgumentError) }
     end
 
-    context "when klass is a singleton class of an original class" do
-      let(:klass) { original_class.singleton_class }
+    # These test cases would fail due to a JRuby bug
+    # Skipping to make build pass until the bug is fixed
+    # https://github.com/jruby/jruby/issues/6896
+    unless RUBY_PLATFORM == "java"
+      context "when klass is a singleton class of an original class" do
+        let(:klass) { original_class.singleton_class }
 
-      context "when assigned to a constant" do
-        let(:original_class) { String }
+        context "when assigned to a constant" do
+          let(:original_class) { String }
 
-        it { is_expected.to eq(original_class) }
-      end
-
-      context "when singleton class #to_s convention is not followed" do
-        include_context "with context for instance methods"
-
-        let(:original_class) { class_with_memo }
-        let(:klass) do
-          super().tap do |sc|
-            sc.define_singleton_method(:to_s) { "not following convention" }
-          end
+          it { is_expected.to eq(original_class) }
         end
 
-        it { is_expected.to eq(original_class) }
+        context "when singleton class #to_s convention is not followed" do
+          include_context "with context for instance methods"
+
+          let(:original_class) { class_with_memo }
+          let(:klass) do
+            super().tap do |sc|
+              sc.define_singleton_method(:to_s) { "not following convention" }
+            end
+          end
+
+          it { is_expected.to eq(original_class) }
+        end
       end
     end
   end

--- a/spec/memo_wise_spec.rb
+++ b/spec/memo_wise_spec.rb
@@ -307,23 +307,28 @@ RSpec.describe MemoWise do
         end
       end
 
-      context "when defined with scope 'class << self'" do
-        include_context "with context for class methods via scope 'class << self'"
+      # These test cases would fail due to a JRuby bug
+      # Skipping to make build pass until the bug is fixed
+      # https://github.com/jruby/jruby/issues/6896
+      unless RUBY_PLATFORM == "java"
+        context "when defined with scope 'class << self'" do
+          include_context "with context for class methods via scope 'class << self'"
 
-        # Use the class as the target of "#memo_wise shared examples"
-        let(:target) { class_with_memo }
+          # Use the class as the target of "#memo_wise shared examples"
+          let(:target) { class_with_memo }
 
-        it_behaves_like "#memo_wise shared examples"
+          it_behaves_like "#memo_wise shared examples"
 
-        it "creates a class-level instance variable" do
-          # NOTE: this test ensure the inverse test above continues to be valid
-          expect(class_with_memo.instance_variables).to include(:@_memo_wise)
-        end
+          it "creates a class-level instance variable" do
+            # NOTE: this test ensure the inverse test above continues to be valid
+            expect(class_with_memo.instance_variables).to include(:@_memo_wise)
+          end
 
-        it_behaves_like "handles memoized/non-memoized methods with the same name at different scopes" do
-          let(:memoized) { class_with_memo }
-          let(:non_memoized) { class_with_memo.new }
-          let(:non_memoized_name) { :instance }
+          it_behaves_like "handles memoized/non-memoized methods with the same name at different scopes" do
+            let(:memoized) { class_with_memo }
+            let(:non_memoized) { class_with_memo.new }
+            let(:non_memoized_name) { :instance }
+          end
         end
       end
     end
@@ -358,169 +363,169 @@ RSpec.describe MemoWise do
         end
       end
 
-      context "when defined with scope 'module << self'" do
-        include_context "with context for module methods via scope 'class << self'"
+      # These test cases would fail due to a JRuby bug
+      # Skipping to make build pass until the bug is fixed
+      # https://github.com/jruby/jruby/issues/6896
+      unless RUBY_PLATFORM == "java"
+        context "when defined with scope 'module << self'" do
+          include_context "with context for module methods via scope 'class << self'"
 
-        # Use the module as the target of "#memo_wise shared examples"
-        let(:target) { module_with_memo }
+          # Use the module as the target of "#memo_wise shared examples"
+          let(:target) { module_with_memo }
 
-        it_behaves_like "#memo_wise shared examples"
+          it_behaves_like "#memo_wise shared examples"
 
-        it "creates a module-level instance variable" do
-          # NOTE: this test ensure the inverse test above continues to be valid
-          expect(module_with_memo.instance_variables).to include(:@_memo_wise)
+          it "creates a module-level instance variable" do
+            # NOTE: this test ensure the inverse test above continues to be valid
+            expect(module_with_memo.instance_variables).to include(:@_memo_wise)
+          end
         end
       end
     end
 
-    # These test cases would fail due to a JRuby bug
-    # Skipping to make build pass until the bug is fixed
-    # https://github.com/jruby/jruby/issues/6758
-    unless RUBY_PLATFORM == "java"
-      context "with module mixed into other classes" do
-        context "when extended" do
-          context "when defined with 'def'" do
-            include_context "with context for module methods via normal scope"
+    context "with module mixed into other classes" do
+      context "when extended" do
+        context "when defined with 'def'" do
+          include_context "with context for module methods via normal scope"
 
-            before(:each) { stub_const("ModuleWithMemo", module_with_memo) }
+          before(:each) { stub_const("ModuleWithMemo", module_with_memo) }
 
-            let(:class_extending_module_with_memo) do
-              Class.new do
-                extend ModuleWithMemo
-              end
+          let(:class_extending_module_with_memo) do
+            Class.new do
+              extend ModuleWithMemo
             end
-
-            let(:target) { class_extending_module_with_memo }
-
-            it_behaves_like "#memo_wise shared examples"
           end
 
-          context "when 1 module extended by 2 classes" do
-            let(:module_with_memo) do
-              Module.new do
-                prepend MemoWise
+          let(:target) { class_extending_module_with_memo }
 
-                def test_method
-                  Random.rand
-                end
-                memo_wise :test_method
-              end
-            end
-            let(:class_a_extending_module_with_memo) do
-              Class.new do
-                extend ModuleWithMemo
-              end
-            end
-            let(:class_b_extending_module_with_memo) do
-              Class.new do
-                extend ModuleWithMemo
-              end
-            end
+          it_behaves_like "#memo_wise shared examples"
+        end
 
-            before(:each) do
-              stub_const("ModuleWithMemo", module_with_memo)
-            end
+        context "when 1 module extended by 2 classes" do
+          let(:module_with_memo) do
+            Module.new do
+              prepend MemoWise
 
-            it "memoizes each extended class separately" do
-              aggregate_failures do
-                expect(class_a_extending_module_with_memo.test_method).
-                  to eq(class_a_extending_module_with_memo.test_method)
-                expect(class_b_extending_module_with_memo.test_method).
-                  to eq(class_b_extending_module_with_memo.test_method)
-                expect(class_a_extending_module_with_memo.test_method).
-                  to_not eq(class_b_extending_module_with_memo.test_method)
+              def test_method
+                Random.rand
               end
+              memo_wise :test_method
+            end
+          end
+          let(:class_a_extending_module_with_memo) do
+            Class.new do
+              extend ModuleWithMemo
+            end
+          end
+          let(:class_b_extending_module_with_memo) do
+            Class.new do
+              extend ModuleWithMemo
+            end
+          end
+
+          before(:each) do
+            stub_const("ModuleWithMemo", module_with_memo)
+          end
+
+          it "memoizes each extended class separately" do
+            aggregate_failures do
+              expect(class_a_extending_module_with_memo.test_method).
+                to eq(class_a_extending_module_with_memo.test_method)
+              expect(class_b_extending_module_with_memo.test_method).
+                to eq(class_b_extending_module_with_memo.test_method)
+              expect(class_a_extending_module_with_memo.test_method).
+                to_not eq(class_b_extending_module_with_memo.test_method)
             end
           end
         end
+      end
 
-        context "when included" do
-          context "when defined with 'def'" do
-            include_context "with context for module methods via normal scope"
+      context "when included" do
+        context "when defined with 'def'" do
+          include_context "with context for module methods via normal scope"
 
-            before(:each) do
-              stub_const("ModuleWithMemo", module_with_memo)
-            end
-
-            let(:class_including_module_with_memo) do
-              Class.new do
-                include ModuleWithMemo
-              end
-            end
-            let(:instance) { class_including_module_with_memo.new }
-
-            let(:target) { instance }
-
-            it_behaves_like "#memo_wise shared examples"
-
-            it_behaves_like "handles memoized/non-memoized methods with the same name at different scopes" do
-              let(:memoized) { instance }
-              let(:non_memoized) { module_with_memo }
-              let(:non_memoized_name) { :module }
-            end
+          before(:each) do
+            stub_const("ModuleWithMemo", module_with_memo)
           end
 
-          context "when defined with 'def self.' and 'def'" do
-            let(:module_with_memo) do
-              Module.new do
-                prepend MemoWise
-
-                def self.test_method
-                  Random.rand
-                end
-                memo_wise self: :test_method
-
-                def test_method
-                  Random.rand
-                end
-                memo_wise :test_method
-              end
+          let(:class_including_module_with_memo) do
+            Class.new do
+              include ModuleWithMemo
             end
-            let(:class_including_module_with_memo) do
-              Class.new do
-                include ModuleWithMemo
-              end
-            end
-            let(:instance) { class_including_module_with_memo.new }
+          end
+          let(:instance) { class_including_module_with_memo.new }
 
-            before(:each) do
-              stub_const("ModuleWithMemo", module_with_memo)
-            end
+          let(:target) { instance }
 
-            it "memoizes instance and singleton methods separately" do
-              aggregate_failures do
-                expect(instance.test_method).to eq(instance.test_method)
-                expect(module_with_memo.test_method).to eq(module_with_memo.test_method)
-                expect(instance.test_method).to_not eq(module_with_memo.test_method)
-              end
-            end
+          it_behaves_like "#memo_wise shared examples"
+
+          it_behaves_like "handles memoized/non-memoized methods with the same name at different scopes" do
+            let(:memoized) { instance }
+            let(:non_memoized) { module_with_memo }
+            let(:non_memoized_name) { :module }
           end
         end
 
-        context "when prepended" do
-          context "when defined with 'def'" do
-            include_context "with context for module methods via normal scope"
+        context "when defined with 'def self.' and 'def'" do
+          let(:module_with_memo) do
+            Module.new do
+              prepend MemoWise
 
-            before(:each) do
-              stub_const("ModuleWithMemo", module_with_memo)
-            end
-
-            let(:class_prepending_module_with_memo) do
-              Class.new do
-                prepend ModuleWithMemo
+              def self.test_method
+                Random.rand
               end
+              memo_wise self: :test_method
+
+              def test_method
+                Random.rand
+              end
+              memo_wise :test_method
             end
-            let(:instance) { class_prepending_module_with_memo.new }
-
-            let(:target) { instance }
-
-            it_behaves_like "#memo_wise shared examples"
-
-            it_behaves_like "handles memoized/non-memoized methods with the same name at different scopes" do
-              let(:memoized) { instance }
-              let(:non_memoized) { module_with_memo }
-              let(:non_memoized_name) { :module }
+          end
+          let(:class_including_module_with_memo) do
+            Class.new do
+              include ModuleWithMemo
             end
+          end
+          let(:instance) { class_including_module_with_memo.new }
+
+          before(:each) do
+            stub_const("ModuleWithMemo", module_with_memo)
+          end
+
+          it "memoizes instance and singleton methods separately" do
+            aggregate_failures do
+              expect(instance.test_method).to eq(instance.test_method)
+              expect(module_with_memo.test_method).to eq(module_with_memo.test_method)
+              expect(instance.test_method).to_not eq(module_with_memo.test_method)
+            end
+          end
+        end
+      end
+
+      context "when prepended" do
+        context "when defined with 'def'" do
+          include_context "with context for module methods via normal scope"
+
+          before(:each) do
+            stub_const("ModuleWithMemo", module_with_memo)
+          end
+
+          let(:class_prepending_module_with_memo) do
+            Class.new do
+              prepend ModuleWithMemo
+            end
+          end
+          let(:instance) { class_prepending_module_with_memo.new }
+
+          let(:target) { instance }
+
+          it_behaves_like "#memo_wise shared examples"
+
+          it_behaves_like "handles memoized/non-memoized methods with the same name at different scopes" do
+            let(:memoized) { instance }
+            let(:non_memoized) { module_with_memo }
+            let(:non_memoized_name) { :module }
           end
         end
       end

--- a/spec/preset_memo_wise_spec.rb
+++ b/spec/preset_memo_wise_spec.rb
@@ -450,62 +450,67 @@ RSpec.describe MemoWise do
         end
       end
 
-      context "when defined with scope 'class << self'" do
-        include_context "with context for class methods via scope 'class << self'"
+      # These test cases would fail due to a JRuby bug
+      # Skipping to make build pass until the bug is fixed
+      # https://github.com/jruby/jruby/issues/6896
+      unless RUBY_PLATFORM == "java"
+        context "when defined with scope 'class << self'" do
+          include_context "with context for class methods via scope 'class << self'"
 
-        # Use the class as the target of "#preset_memo_wise shared examples"
-        let(:target) { class_with_memo }
+          # Use the class as the target of "#preset_memo_wise shared examples"
+          let(:target) { class_with_memo }
 
-        context "when memoized values were not already set" do
-          it_behaves_like "#preset_memo_wise shared examples", overriding: false
-        end
+          context "when memoized values were not already set" do
+            it_behaves_like "#preset_memo_wise shared examples", overriding: false
+          end
 
-        context "when memoized values were already set" do
-          it_behaves_like "#preset_memo_wise shared examples", overriding: true
-        end
+          context "when memoized values were already set" do
+            it_behaves_like "#preset_memo_wise shared examples", overriding: true
+          end
 
-        context "when method name is the same as a memoized instance method" do
-          let(:class_with_memo) do
-            Class.new do
-              prepend MemoWise
-
-              def instance_one_arg_counter
-                @instance_one_arg_counter || 0
-              end
-
-              def one_arg(a) # rubocop:disable Naming/MethodParameterName
-                @instance_one_arg_counter = instance_one_arg_counter + 1
-                "instance_one_arg: a=#{a}"
-              end
-              memo_wise :one_arg
-
-              class << self
+          context "when method name is the same as a memoized instance method" do
+            let(:class_with_memo) do
+              Class.new do
                 prepend MemoWise
 
-                def class_one_arg_counter
-                  @class_one_arg_counter || 0
+                def instance_one_arg_counter
+                  @instance_one_arg_counter || 0
                 end
 
                 def one_arg(a) # rubocop:disable Naming/MethodParameterName
-                  @class_one_arg_counter = class_one_arg_counter + 1
-                  "class_one_arg: a=#{a}"
+                  @instance_one_arg_counter = instance_one_arg_counter + 1
+                  "instance_one_arg: a=#{a}"
                 end
                 memo_wise :one_arg
+
+                class << self
+                  prepend MemoWise
+
+                  def class_one_arg_counter
+                    @class_one_arg_counter || 0
+                  end
+
+                  def one_arg(a) # rubocop:disable Naming/MethodParameterName
+                    @class_one_arg_counter = class_one_arg_counter + 1
+                    "class_one_arg: a=#{a}"
+                  end
+                  memo_wise :one_arg
+                end
               end
             end
-          end
 
-          it "presets memoization independently" do
-            instance = class_with_memo.new
-            instance.preset_memo_wise(:one_arg, 1) { "preset_instance_one_arg: a=1" }
+            it "presets memoization independently" do
+              instance = class_with_memo.new
+              instance.preset_memo_wise(:one_arg, 1) { "preset_instance_one_arg: a=1" }
 
-            expect(Array.new(4) { instance.one_arg(1) }).to all eq("preset_instance_one_arg: a=1")
-            expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
+              expect(Array.new(4) { instance.one_arg(1) }).to all eq("preset_instance_one_arg: a=1")
+              expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
 
-            class_with_memo.preset_memo_wise(:one_arg, 1) { "preset_class_one_arg: a=1" }
+              class_with_memo.preset_memo_wise(:one_arg, 1) { "preset_class_one_arg: a=1" }
 
-            expect(Array.new(4) { instance.one_arg(1) }).to all eq("preset_instance_one_arg: a=1")
-            expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("preset_class_one_arg: a=1")
+              expect(Array.new(4) { instance.one_arg(1) }).to all eq("preset_instance_one_arg: a=1")
+              expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("preset_class_one_arg: a=1")
+            end
           end
         end
       end


### PR DESCRIPTION
Some tests crash the JRuby interpreter due to this
JRuby bug: https://github.com/jruby/jruby/issues/6896

This commit temporarily disables those tests so our
CI builds can pass. Once JRuby fixes the bug we will
remove these workarounds.

**Before merging:**

- [ ] ~Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR~
- [ ] ~If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)~
