### PR TITLE
Remove usages of #hash to avoid potential hash collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve performance of single-argument methods by using an outer Array instead
   of a Hash
 ### Fixed
-- (Nothing, yet)
+- Removed use of #hash due to potential of hash collisions
 ### Breaking Changes
 - None
 

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -480,20 +480,20 @@ module MemoWise
       hash[kwargs.first.last] = yield
     when MemoWise::InternalAPI::SPLAT
       hash = (@_memo_wise_multi_argument[method_name] ||= {})
-      hash[args.hash] = yield
+      hash[args] = yield
     when MemoWise::InternalAPI::DOUBLE_SPLAT
       hash = (@_memo_wise_multi_argument[method_name] ||= {})
-      hash[kwargs.hash] = yield
+      hash[kwargs] = yield
     when MemoWise::InternalAPI::MULTIPLE_REQUIRED
       key_args = method.parameters.map.with_index do |(type, name), idx|
         type == :req ? args[idx] : kwargs[name]
       end
-      key = [method_name, *key_args].hash
+      key = [method_name, *key_args]
       hashes = (@_memo_wise_hashes[method_name] ||= Set.new)
       hashes << key
       @_memo_wise_multi_argument[key] = yield
     else # MemoWise::InternalAPI::SPLAT_AND_DOUBLE_SPLAT
-      key = [method_name, args, kwargs].hash
+      key = [method_name, args, kwargs]
       hashes = (@_memo_wise_hashes[method_name] ||= Set.new)
       hashes << key
       @_memo_wise_multi_argument[key] = yield
@@ -612,13 +612,13 @@ module MemoWise
       if args.empty?
         @_memo_wise_multi_argument.delete(method_name)
       else
-        @_memo_wise_multi_argument[method_name]&.delete(args.hash)
+        @_memo_wise_multi_argument[method_name]&.delete(args)
       end
     when MemoWise::InternalAPI::DOUBLE_SPLAT
       if kwargs.empty?
         @_memo_wise_multi_argument.delete(method_name)
       else
-        @_memo_wise_multi_argument[method_name]&.delete(kwargs.hash)
+        @_memo_wise_multi_argument[method_name]&.delete(kwargs)
       end
     else # MemoWise::InternalAPI::MULTIPLE_REQUIRED, MemoWise::InternalAPI::SPLAT_AND_DOUBLE_SPLAT
       if args.empty? && kwargs.empty?
@@ -629,12 +629,12 @@ module MemoWise
         @_memo_wise_hashes.delete(method_name)
       else
         if method_arguments == MemoWise::InternalAPI::SPLAT_AND_DOUBLE_SPLAT
-          key = [method_name, args, kwargs].hash
+          key = [method_name, args, kwargs]
         else
           key_args = method.parameters.map.with_index do |(type, name), i|
             type == :req ? args[i] : kwargs[name] # rubocop:disable Metrics/BlockNesting
           end
-          key = [method_name, *key_args].hash
+          key = [method_name, *key_args]
         end
         @_memo_wise_hashes[method_name]&.delete(key)
         @_memo_wise_multi_argument.delete(key)

--- a/lib/memo_wise/internal_api.rb
+++ b/lib/memo_wise/internal_api.rb
@@ -17,7 +17,7 @@ module MemoWise
       # `@_memo_wise_multi_argument` looks like:
       #   {
       #     no_args_method_name: :memoized_result,
-      #     [:multi_arg_method_name, arg1, arg2].hash => :memoized_result
+      #     [:multi_arg_method_name, arg1, arg2] => :memoized_result
       #   }
       #
       # `@_memo_wise` looks like:
@@ -68,8 +68,8 @@ module MemoWise
       # resetting memoization for an entire method. It looks like:
       #   {
       #     multi_arg_method_name: Set[
-      #       [:multi_arg_method_name, arg1, arg2].hash,
-      #       [:multi_arg_method_name, arg1, arg3].hash,
+      #       [:multi_arg_method_name, arg1, arg2],
+      #       [:multi_arg_method_name, arg1, arg3],
       #       ...
       #     ],
       #     ...
@@ -155,10 +155,10 @@ module MemoWise
     #   memoized value, based on the method's arguments
     def self.key_str(method)
       case method_arguments(method)
-      when SPLAT then "args.hash"
-      when DOUBLE_SPLAT then "kwargs.hash"
-      when SPLAT_AND_DOUBLE_SPLAT then "[:#{method.name}, args, kwargs].hash"
-      when MULTIPLE_REQUIRED then "[:#{method.name}, #{method.parameters.map(&:last).join(', ')}].hash"
+      when SPLAT then "args"
+      when DOUBLE_SPLAT then "kwargs"
+      when SPLAT_AND_DOUBLE_SPLAT then "[:#{method.name}, args, kwargs]"
+      when MULTIPLE_REQUIRED then "[:#{method.name}, #{method.parameters.map(&:last).join(', ')}]"
       else
         raise ArgumentError, "Unexpected arguments for #{method.name}"
       end


### PR DESCRIPTION
This PR removes usage of #hash because there is a potential for hash collisions leading to incorrect memoized results in our current implementation. 

See [this issue](https://github.com/dry-rb/dry-core/issues/63) for further explanation.

Still todo on this PR:

- [ ] Once benchmarks run, add content around what we do differently than dry-rb
- [ ] Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR
- [X] If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)
