### PR TITLE
Fix thread-safety for concurrent uncached calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- Fix theoretical thread-safety issue for concurrent calls to an uncached
-  zero argument method
+- Fix thread-safety issue in concurrent calls to zero-arg method in unmemoized
+  state which resulted in a `nil` value being accidentally returned in one thread
 
 ## [1.2.0] - 2021-11-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- Nothing yet!
+- Fix theoretical thread-safety issue for concurrent calls to an uncached
+  zero argument method
 
 ## [1.2.0] - 2021-11-10
 

--- a/README.md
+++ b/README.md
@@ -117,15 +117,15 @@ Results using Ruby 3.0.2:
 
 |Method arguments|`Dry::Core`\* (0.7.1)|`Memery` (1.4.0)|
 |--|--|--|
-|`()` (none)|1.51x|19.82x|
-|`(a)`|2.30x|11.38x|
-|`(a, b)`|0.45x|2.10x|
-|`(a:)`|2.20x|22.83x|
-|`(a:, b:)`|0.49x|4.53x|
-|`(a, b:)`|0.46x|4.35x|
-|`(a, *args)`|0.89x|2.03x|
-|`(a:, **kwargs)`|0.82x|3.18x|
-|`(a, *args, b:, **kwargs)`|0.60x|1.62x|
+|`()` (none)|1.42x|17.84x|
+|`(a)`|2.48x|11.48x|
+|`(a, b)`|0.46x|2.05x|
+|`(a:)`|2.18x|20.50x|
+|`(a:, b:)`|0.48x|4.22x|
+|`(a, b:)`|0.48x|4.08x|
+|`(a, *args)`|0.90x|1.97x|
+|`(a:, **kwargs)`|0.80x|3.02x|
+|`(a, *args, b:, **kwargs)`|0.61x|1.54x|
 
 \* `Dry::Core`
 [may cause incorrect behavior caused by hash collisions](https://github.com/dry-rb/dry-core/issues/63).
@@ -134,15 +134,15 @@ Results using Ruby 2.7.4 (because these gems raise errors in Ruby 3.x):
 
 |Method arguments|`DDMemoize` (1.0.0)|`Memoist` (0.16.2)|`Memoized` (1.0.2)|`Memoizer` (1.0.3)|
 |--|--|--|--|--|
-|`()` (none)|35.29x|3.46x|1.67x|4.27x|
-|`(a)`|25.04x|16.96x|12.83x|14.68x|
-|`(a, b)`|3.20x|2.28x|1.84x|2.04x|
-|`(a:)`|34.17x|27.77x|24.07x|25.39x|
-|`(a:, b:)`|5.22x|4.29x|3.74x|4.00x|
-|`(a, b:)`|4.81x|3.99x|3.49x|3.66x|
-|`(a, *args)`|3.21x|2.30x|1.97x|2.00x|
-|`(a:, **kwargs)`|2.84x|2.39x|2.12x|2.19x|
-|`(a, *args, b:, **kwargs)`|2.10x|1.80x|1.67x|1.66x|
+|`()` (none)|33.90x|3.44x|1.56x|4.03x|
+|`(a)`|24.56x|17.02x|12.94x|14.91x|
+|`(a, b)`|3.14x|2.35x|1.84x|2.03x|
+|`(a:)`|34.42x|28.14x|23.83x|25.26x|
+|`(a:, b:)`|5.13x|4.28x|3.77x|3.97x|
+|`(a, b:)`|4.83x|4.08x|3.50x|3.66x|
+|`(a, *args)`|3.03x|2.25x|1.95x|1.95x|
+|`(a:, **kwargs)`|2.90x|2.44x|2.14x|2.24x|
+|`(a, *args, b:, **kwargs)`|2.05x|1.77x|1.65x|1.64x|
 
 You can run benchmarks yourself with:
 

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -187,12 +187,11 @@ module MemoWise
           # hash key is just the method name.
           klass.module_eval <<-END_OF_METHOD, __FILE__, __LINE__ + 1
             def #{method_name}
-              _memo_wise_output = @_memo_wise[#{index}]
-              if _memo_wise_output || @_memo_wise_sentinels[#{index}]
-                _memo_wise_output
+              if @_memo_wise_sentinels[#{index}]
+                @_memo_wise[#{index}]
               else
-                @_memo_wise_sentinels[#{index}] = true
                 @_memo_wise[#{index}] = #{original_memo_wised_name}
+                @_memo_wise_sentinels[#{index}] = true
               end
             end
           END_OF_METHOD

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -192,6 +192,11 @@ module MemoWise
               else
                 ret = @_memo_wise[#{index}] = #{original_memo_wised_name}
                 @_memo_wise_sentinels[#{index}] = true
+                #unless frozen?
+                #  define_singleton_method(:#{method_name}) do
+                #    ret
+                #  end
+                #end
                 ret
               end
             end

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -192,11 +192,6 @@ module MemoWise
               else
                 ret = @_memo_wise[#{index}] = #{original_memo_wised_name}
                 @_memo_wise_sentinels[#{index}] = true
-                #unless frozen?
-                #  define_singleton_method(:#{method_name}) do
-                #    ret
-                #  end
-                #end
                 ret
               end
             end

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -190,8 +190,9 @@ module MemoWise
               if @_memo_wise_sentinels[#{index}]
                 @_memo_wise[#{index}]
               else
-                @_memo_wise[#{index}] = #{original_memo_wised_name}
+                ret = @_memo_wise[#{index}] = #{original_memo_wised_name}
                 @_memo_wise_sentinels[#{index}] = true
+                ret
               end
             end
           END_OF_METHOD

--- a/spec/thread_safety_spec.rb
+++ b/spec/thread_safety_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe "thread safety" do # rubocop:disable RSpec/DescribeClass
     # to unmemoized zero-args methods.
     #   * See https://github.com/panorama-ed/memo_wise/pull/224
     it "does not return accidental nil value to either thread" do
-      pending("fix for zero-arg race condition in #224")
       expect(thread_return_values).not_to include(nil)
     end
   end


### PR DESCRIPTION
This updates the sentinel after updating the cache, and check the sentinel before checking the cache.  Otherwise, if there are two concurrent calls for an uncached value in separate threads, a thread-safety issue is possible:

1. Thread 1 sets sentinel value to true
2. Thread 2 gets cached value (nil is not set)
3. Thread 2 checks sentinel value (is true)
4. Thread 2 returns nil instead of correct value
5. Thread 1 sets cached value

This changes the behavior so that in the case of concurrent calls for an uncached value, the original method is called twice instead of in invalid value being returned.

This change may negatively affect performance for cached calls, I haven't benchmarked or tested this.

**Before merging:**

- [x] Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR
- [x] If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)

I'll leave the before merging changes to the maintainers if they choose to accept this.