### PR TITLE
Fix a variety of inheritance bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 - Fix thread-safety issue in concurrent calls to zero-arg method in unmemoized
   state which resulted in a `nil` value being accidentally returned in one thread
+- Fix bugs related to child classes inheriting from parent classes that use
+  `MemoWise`
 
 ## [1.2.0] - 2021-11-10
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   * Support for [resetting](https://rubydoc.info/github/panorama-ed/memo_wise/MemoWise#reset_memo_wise-instance_method) and [presetting](https://rubydoc.info/github/panorama-ed/memo_wise/MemoWise#preset_memo_wise-instance_method) memoized values
   * Support for memoization on frozen objects
   * Support for memoization of class and module methods
+  * Support for inheritance of memoized class and instance methods
   * Full [documentation](https://rubydoc.info/github/panorama-ed/memo_wise/MemoWise) and [test coverage](https://codecov.io/gh/panorama-ed/memo_wise)!
 
 ## Installation

--- a/spec/adding_methods_spec.rb
+++ b/spec/adding_methods_spec.rb
@@ -44,5 +44,30 @@ RSpec.describe "adding methods" do # rubocop:disable RSpec/DescribeClass
       expect { subject }.
         not_to change { klass.singleton_class.private_methods.to_set }
     end
+
+    # These test cases would fail due to a JRuby bug
+    # Skipping to make build pass until the bug is fixed
+    unless RUBY_PLATFORM == "java"
+      context "when a class method is memoized" do
+        subject do
+          klass.send(:prepend, MemoWise)
+          klass.send(:memo_wise, self: :example)
+        end
+
+        let(:klass) do
+          Class.new do
+            def self.example; end
+          end
+        end
+
+        let(:expected_public_class_methods) { super() << :inherited }
+
+        it "adds expected public *instance* methods only" do
+          expect { subject }.
+            to change { klass.singleton_methods.to_set }.
+            by(expected_public_class_methods)
+        end
+      end
+    end
   end
 end

--- a/spec/memo_wise_spec.rb
+++ b/spec/memo_wise_spec.rb
@@ -269,48 +269,122 @@ RSpec.describe MemoWise do
           expect(external_counter[0]).to eq(1)
         end
       end
-    end
 
-    context "with class methods" do
-      context "when defined with 'def self.'" do
-        include_context "with context for class methods via 'def self.'"
+      context "when the class has a child class" do
+        let(:child_class) do
+          Class.new(class_with_memo) do
+            def child_method_counter
+              @child_method_counter || 0
+            end
 
-        # Use the class as the target of "#memo_wise shared examples"
-        let(:target) { class_with_memo }
-
-        it_behaves_like "#memo_wise shared examples"
-
-        it "creates a class-level instance variable" do
-          # NOTE: test implementation detail to ensure the inverse test is valid
-          expect(class_with_memo.instance_variables).to include(:@_memo_wise)
-        end
-
-        it_behaves_like "handles memoized/non-memoized methods with the same name at different scopes" do
-          let(:memoized) { class_with_memo }
-          let(:non_memoized) { class_with_memo.new }
-          let(:non_memoized_name) { :instance }
-        end
-
-        context "when an invalid hash key is passed to .memo_wise" do
-          let(:class_with_memo) do
-            Class.new do
-              prepend MemoWise
-
-              def self.class_method; end
+            def child_method
+              @child_method_counter = child_method_counter + 1
+              "child_method"
             end
           end
+        end
 
-          it "raises an error when passing a key which is not `self:`" do
-            expect { class_with_memo.send(:memo_wise, bad_key: :class_method) }.
-              to raise_error(ArgumentError, "`:self` is the only key allowed in memo_wise")
+        let(:instance) { child_class.new }
+
+        it "memoizes the parent methods" do
+          expect(Array.new(4) { instance.no_args }).to all eq("no_args")
+          expect(instance.no_args_counter).to eq(1)
+          expect(Array.new(4) { instance.child_method }).to all eq("child_method")
+          expect(instance.child_method_counter).to eq(4)
+        end
+
+        context "when the child class also memoizes methods" do
+          before :each do
+            child_class.prepend described_class
+            child_class.memo_wise :child_method
+          end
+
+          it "memoizes the parent and child methods separately" do
+            expect(Array.new(4) { instance.no_args }).to all eq("no_args")
+            expect(instance.no_args_counter).to eq(1)
+            expect(Array.new(4) { instance.child_method }).to all eq("child_method")
+            expect(instance.child_method_counter).to eq(1)
           end
         end
       end
+    end
 
-      # These test cases would fail due to a JRuby bug
-      # Skipping to make build pass until the bug is fixed
-      # https://github.com/jruby/jruby/issues/6896
-      unless RUBY_PLATFORM == "java"
+    # These test cases would fail due to a JRuby bug
+    # Skipping to make build pass until the bug is fixed
+    # https://github.com/jruby/jruby/issues/6896
+    unless RUBY_PLATFORM == "java"
+      context "with class methods" do
+        context "when defined with 'def self.'" do
+          include_context "with context for class methods via 'def self.'"
+
+          # Use the class as the target of "#memo_wise shared examples"
+          let(:target) { class_with_memo }
+
+          it_behaves_like "#memo_wise shared examples"
+
+          it "creates a class-level instance variable" do
+            # NOTE: test implementation detail to ensure the inverse test is valid
+            expect(class_with_memo.instance_variables).to include(:@_memo_wise)
+          end
+
+          it_behaves_like "handles memoized/non-memoized methods with the same name at different scopes" do
+            let(:memoized) { class_with_memo }
+            let(:non_memoized) { class_with_memo.new }
+            let(:non_memoized_name) { :instance }
+          end
+
+          context "when an invalid hash key is passed to .memo_wise" do
+            let(:class_with_memo) do
+              Class.new do
+                prepend MemoWise
+
+                def self.class_method; end
+              end
+            end
+
+            it "raises an error when passing a key which is not `self:`" do
+              expect { class_with_memo.send(:memo_wise, bad_key: :class_method) }.
+                to raise_error(ArgumentError, "`:self` is the only key allowed in memo_wise")
+            end
+          end
+
+          context "when the class has a child class" do
+            let(:child_class) do
+              Class.new(class_with_memo) do
+                def self.child_method_counter
+                  @child_method_counter || 0
+                end
+
+                def self.child_method
+                  @child_method_counter = child_method_counter + 1
+                  "child_method"
+                end
+              end
+            end
+
+            it "memoizes the parent methods" do
+              expect(Array.new(4) { child_class.no_args }).to all eq("no_args")
+              expect(child_class.no_args_counter).to eq(1)
+              expect(Array.new(4) { child_class.child_method }).to all eq("child_method")
+              expect(child_class.child_method_counter).to eq(4)
+            end
+
+            context "when the child class also memoizes methods" do
+              before :each do
+                child_class.prepend described_class
+                child_class.memo_wise self: :child_method
+              end
+
+              it "memoizes the parent and child methods separately" do
+                expect(Array.new(4) { child_class.no_args }).to all eq("no_args")
+                expect(child_class.no_args_counter).to eq(1)
+                expect(Array.new(4) { child_class.child_method }).to all eq("child_method")
+                expect(child_class.child_method_counter).to eq(1)
+              end
+            end
+          end
+        end
+
         context "when defined with scope 'class << self'" do
           include_context "with context for class methods via scope 'class << self'"
 
@@ -329,44 +403,95 @@ RSpec.describe MemoWise do
             let(:non_memoized) { class_with_memo.new }
             let(:non_memoized_name) { :instance }
           end
+
+          context "when the class has a child class" do
+            let(:child_class) do
+              Class.new(class_with_memo) do
+                class << self
+                  def child_method_counter
+                    @child_method_counter || 0
+                  end
+
+                  def child_method
+                    @child_method_counter = child_method_counter + 1
+                    "child_method"
+                  end
+                end
+              end
+            end
+
+            it "memoizes the parent methods" do
+              expect(Array.new(4) { child_class.no_args }).to all eq("no_args")
+              expect(child_class.no_args_counter).to eq(1)
+              expect(Array.new(4) { child_class.child_method }).to all eq("child_method")
+              expect(child_class.child_method_counter).to eq(4)
+            end
+
+            context "when the child class also memoizes methods" do
+              let(:child_class) do
+                Class.new(class_with_memo) do
+                  class << self
+                    prepend MemoWise
+
+                    def child_method_counter
+                      @child_method_counter || 0
+                    end
+
+                    def child_method
+                      @child_method_counter = child_method_counter + 1
+                      "child_method"
+                    end
+                    memo_wise :child_method
+                  end
+                end
+              end
+
+              it "memoizes the parent and child methods separately" do
+                expect(Array.new(4) { child_class.no_args }).to all eq("no_args")
+                expect(child_class.no_args_counter).to eq(1)
+                expect(Array.new(4) { child_class.child_method }).to all eq("child_method")
+                expect(child_class.child_method_counter).to eq(1)
+              end
+            end
+          end
         end
       end
     end
 
-    context "with module methods" do
-      context "when defined with 'def self.'" do
-        include_context "with context for module methods via 'def self.'"
+    # These test cases would fail due to a JRuby bug
+    # Skipping to make build pass until the bug is fixed
+    # https://github.com/jruby/jruby/issues/6896
+    unless RUBY_PLATFORM == "java"
+      context "with module methods" do
+        context "when defined with 'def self.'" do
+          include_context "with context for module methods via 'def self.'"
 
-        # Use the module as the target of "#memo_wise shared examples"
-        let(:target) { module_with_memo }
+          # Use the module as the target of "#memo_wise shared examples"
+          let(:target) { module_with_memo }
 
-        it_behaves_like "#memo_wise shared examples"
+          it_behaves_like "#memo_wise shared examples"
 
-        it "creates a module-level instance variable" do
-          # NOTE: test implementation detail to ensure the inverse test is valid
-          expect(module_with_memo.instance_variables).to include(:@_memo_wise)
-        end
+          it "creates a module-level instance variable" do
+            # NOTE: test implementation detail to ensure the inverse test is valid
+            expect(module_with_memo.instance_variables).to include(:@_memo_wise)
+          end
 
-        context "when an invalid hash key is passed to .memo_wise" do
-          let(:module_with_memo) do
-            Module.new do
-              prepend MemoWise
+          context "when an invalid hash key is passed to .memo_wise" do
+            let(:module_with_memo) do
+              Module.new do
+                prepend MemoWise
 
-              def self.module_method; end
+                def self.module_method; end
+              end
+            end
+
+            it "raises an error when passing a key which is not `self:`" do
+              expect { module_with_memo.send(:memo_wise, bad_key: :module_method) }.
+                to raise_error(ArgumentError, "`:self` is the only key allowed in memo_wise")
             end
           end
-
-          it "raises an error when passing a key which is not `self:`" do
-            expect { module_with_memo.send(:memo_wise, bad_key: :module_method) }.
-              to raise_error(ArgumentError, "`:self` is the only key allowed in memo_wise")
-          end
         end
-      end
 
-      # These test cases would fail due to a JRuby bug
-      # Skipping to make build pass until the bug is fixed
-      # https://github.com/jruby/jruby/issues/6896
-      unless RUBY_PLATFORM == "java"
         context "when defined with scope 'module << self'" do
           include_context "with context for module methods via scope 'class << self'"
 
@@ -466,38 +591,42 @@ RSpec.describe MemoWise do
           end
         end
 
-        context "when defined with 'def self.' and 'def'" do
-          let(:module_with_memo) do
-            Module.new do
-              prepend MemoWise
+        # These test cases would fail due to a JRuby bug
+        # Skipping to make build pass until the bug is fixed
+        unless RUBY_PLATFORM == "java"
+          context "when defined with 'def self.' and 'def'" do
+            let(:module_with_memo) do
+              Module.new do
+                prepend MemoWise
 
-              def self.test_method
-                Random.rand
+                def self.test_method
+                  Random.rand
+                end
+                memo_wise self: :test_method
+
+                def test_method
+                  Random.rand
+                end
+                memo_wise :test_method
               end
-              memo_wise self: :test_method
-
-              def test_method
-                Random.rand
+            end
+            let(:class_including_module_with_memo) do
+              Class.new do
+                include ModuleWithMemo
               end
-              memo_wise :test_method
             end
-          end
-          let(:class_including_module_with_memo) do
-            Class.new do
-              include ModuleWithMemo
+            let(:instance) { class_including_module_with_memo.new }
+
+            before(:each) do
+              stub_const("ModuleWithMemo", module_with_memo)
             end
-          end
-          let(:instance) { class_including_module_with_memo.new }
 
-          before(:each) do
-            stub_const("ModuleWithMemo", module_with_memo)
-          end
-
-          it "memoizes instance and singleton methods separately" do
-            aggregate_failures do
-              expect(instance.test_method).to eq(instance.test_method)
-              expect(module_with_memo.test_method).to eq(module_with_memo.test_method)
-              expect(instance.test_method).to_not eq(module_with_memo.test_method)
+            it "memoizes instance and singleton methods separately" do
+              aggregate_failures do
+                expect(instance.test_method).to eq(instance.test_method)
+                expect(module_with_memo.test_method).to eq(module_with_memo.test_method)
+                expect(instance.test_method).to_not eq(module_with_memo.test_method)
+              end
             end
           end
         end

--- a/spec/preset_memo_wise_spec.rb
+++ b/spec/preset_memo_wise_spec.rb
@@ -351,64 +351,10 @@ RSpec.describe MemoWise do
         end
       end
 
-      context "when method name is the same as a memoized class method" do
-        let(:class_with_memo) do
-          Class.new do
-            prepend MemoWise
-
-            def instance_one_arg_counter
-              @instance_one_arg_counter || 0
-            end
-
-            def one_arg(a) # rubocop:disable Naming/MethodParameterName
-              @instance_one_arg_counter = instance_one_arg_counter + 1
-              "instance_one_arg: a=#{a}"
-            end
-            memo_wise :one_arg
-
-            def self.class_one_arg_counter
-              @class_one_arg_counter || 0
-            end
-
-            def self.one_arg(a) # rubocop:disable Naming/MethodParameterName
-              @class_one_arg_counter = class_one_arg_counter + 1
-              "class_one_arg: a=#{a}"
-            end
-            memo_wise self: :one_arg
-          end
-        end
-
-        it "presets memoization independently" do
-          instance = class_with_memo.new
-          instance.preset_memo_wise(:one_arg, 1) { "preset_instance_one_arg: a=1" }
-
-          expect(Array.new(4) { instance.one_arg(1) }).to all eq("preset_instance_one_arg: a=1")
-          expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
-
-          class_with_memo.preset_memo_wise(:one_arg, 1) { "preset_class_one_arg: a=1" }
-
-          expect(Array.new(4) { instance.one_arg(1) }).to all eq("preset_instance_one_arg: a=1")
-          expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("preset_class_one_arg: a=1")
-        end
-      end
-    end
-
-    context "with class methods" do
-      context "when defined with 'def self.'" do
-        include_context "with context for class methods via 'def self.'"
-
-        # Use the class as the target of "#preset_memo_wise shared examples"
-        let(:target) { class_with_memo }
-
-        context "when memoized values were not already set" do
-          it_behaves_like "#preset_memo_wise shared examples", overriding: false
-        end
-
-        context "when memoized values were already set" do
-          it_behaves_like "#preset_memo_wise shared examples", overriding: true
-        end
-
-        context "when method name is the same as a memoized instance method" do
+      # These test cases would fail due to a JRuby bug
+      # Skipping to make build pass until the bug is fixed
+      unless RUBY_PLATFORM == "java"
+        context "when method name is the same as a memoized class method" do
           let(:class_with_memo) do
             Class.new do
               prepend MemoWise
@@ -449,11 +395,69 @@ RSpec.describe MemoWise do
           end
         end
       end
+    end
 
-      # These test cases would fail due to a JRuby bug
-      # Skipping to make build pass until the bug is fixed
-      # https://github.com/jruby/jruby/issues/6896
-      unless RUBY_PLATFORM == "java"
+    # These test cases would fail due to a JRuby bug
+    # Skipping to make build pass until the bug is fixed
+    # https://github.com/jruby/jruby/issues/6896
+    unless RUBY_PLATFORM == "java"
+      context "with class methods" do
+        context "when defined with 'def self.'" do
+          include_context "with context for class methods via 'def self.'"
+
+          # Use the class as the target of "#preset_memo_wise shared examples"
+          let(:target) { class_with_memo }
+
+          context "when memoized values were not already set" do
+            it_behaves_like "#preset_memo_wise shared examples", overriding: false
+          end
+
+          context "when memoized values were already set" do
+            it_behaves_like "#preset_memo_wise shared examples", overriding: true
+          end
+
+          context "when method name is the same as a memoized instance method" do
+            let(:class_with_memo) do
+              Class.new do
+                prepend MemoWise
+
+                def instance_one_arg_counter
+                  @instance_one_arg_counter || 0
+                end
+
+                def one_arg(a) # rubocop:disable Naming/MethodParameterName
+                  @instance_one_arg_counter = instance_one_arg_counter + 1
+                  "instance_one_arg: a=#{a}"
+                end
+                memo_wise :one_arg
+
+                def self.class_one_arg_counter
+                  @class_one_arg_counter || 0
+                end
+
+                def self.one_arg(a) # rubocop:disable Naming/MethodParameterName
+                  @class_one_arg_counter = class_one_arg_counter + 1
+                  "class_one_arg: a=#{a}"
+                end
+                memo_wise self: :one_arg
+              end
+            end
+
+            it "presets memoization independently" do
+              instance = class_with_memo.new
+              instance.preset_memo_wise(:one_arg, 1) { "preset_instance_one_arg: a=1" }
+
+              expect(Array.new(4) { instance.one_arg(1) }).to all eq("preset_instance_one_arg: a=1")
+              expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
+
+              class_with_memo.preset_memo_wise(:one_arg, 1) { "preset_class_one_arg: a=1" }
+
+              expect(Array.new(4) { instance.one_arg(1) }).to all eq("preset_instance_one_arg: a=1")
+              expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("preset_class_one_arg: a=1")
+            end
+          end
+        end
+
         context "when defined with scope 'class << self'" do
           include_context "with context for class methods via scope 'class << self'"
 

--- a/spec/reset_memo_wise_spec.rb
+++ b/spec/reset_memo_wise_spec.rb
@@ -389,67 +389,10 @@ RSpec.describe MemoWise do
         end
       end
 
-      context "when method name is the same as a memoized class method" do
-        let(:class_with_memo) do
-          Class.new do
-            prepend MemoWise
-
-            def instance_one_arg_counter
-              @instance_one_arg_counter || 0
-            end
-
-            def one_arg(a) # rubocop:disable Naming/MethodParameterName
-              @instance_one_arg_counter = instance_one_arg_counter + 1
-              "instance_one_arg: a=#{a}"
-            end
-            memo_wise :one_arg
-
-            def self.class_one_arg_counter
-              @class_one_arg_counter || 0
-            end
-
-            def self.one_arg(a) # rubocop:disable Naming/MethodParameterName
-              @class_one_arg_counter = class_one_arg_counter + 1
-              "class_one_arg: a=#{a}"
-            end
-            memo_wise self: :one_arg
-          end
-        end
-
-        it "resets memoization independently" do
-          instance = class_with_memo.new
-          expect(Array.new(4) { instance.one_arg(1) }).to all eq("instance_one_arg: a=1")
-          expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
-
-          class_with_memo.reset_memo_wise(:one_arg)
-
-          expect(Array.new(4) { instance.one_arg(1) }).to all eq("instance_one_arg: a=1")
-          expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
-
-          expect(instance.instance_one_arg_counter).to eq 1 # Never reset, so only incremented once.
-          expect(class_with_memo.class_one_arg_counter).to eq 2 # Once initially and once after resetting.
-
-          instance.reset_memo_wise(:one_arg)
-
-          expect(Array.new(4) { instance.one_arg(1) }).to all eq("instance_one_arg: a=1")
-          expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
-
-          expect(instance.instance_one_arg_counter).to eq 2 # Once initially and once after resetting.
-          expect(class_with_memo.class_one_arg_counter).to eq 2 # Once initially and once after resetting.
-        end
-      end
-    end
-
-    context "with class methods" do
-      context "when defined with 'def self.'" do
-        include_context "with context for class methods via 'def self.'"
-
-        # Use the class as the target of "#reset_memo_wise shared examples"
-        let(:target) { class_with_memo }
-
-        it_behaves_like "#reset_memo_wise shared examples"
-
-        context "when method name is the same as a memoized instance method" do
+      # These test cases would fail due to a JRuby bug
+      # Skipping to make build pass until the bug is fixed
+      unless RUBY_PLATFORM == "java"
+        context "when method name is the same as a memoized class method" do
           let(:class_with_memo) do
             Class.new do
               prepend MemoWise
@@ -499,11 +442,72 @@ RSpec.describe MemoWise do
           end
         end
       end
+    end
 
-      # These test cases would fail due to a JRuby bug
-      # Skipping to make build pass until the bug is fixed
-      # https://github.com/jruby/jruby/issues/6896
-      unless RUBY_PLATFORM == "java"
+    # These test cases would fail due to a JRuby bug
+    # Skipping to make build pass until the bug is fixed
+    # https://github.com/jruby/jruby/issues/6896
+    unless RUBY_PLATFORM == "java"
+      context "with class methods" do
+        context "when defined with 'def self.'" do
+          include_context "with context for class methods via 'def self.'"
+
+          # Use the class as the target of "#reset_memo_wise shared examples"
+          let(:target) { class_with_memo }
+
+          it_behaves_like "#reset_memo_wise shared examples"
+
+          context "when method name is the same as a memoized instance method" do
+            let(:class_with_memo) do
+              Class.new do
+                prepend MemoWise
+
+                def instance_one_arg_counter
+                  @instance_one_arg_counter || 0
+                end
+
+                def one_arg(a) # rubocop:disable Naming/MethodParameterName
+                  @instance_one_arg_counter = instance_one_arg_counter + 1
+                  "instance_one_arg: a=#{a}"
+                end
+                memo_wise :one_arg
+
+                def self.class_one_arg_counter
+                  @class_one_arg_counter || 0
+                end
+
+                def self.one_arg(a) # rubocop:disable Naming/MethodParameterName
+                  @class_one_arg_counter = class_one_arg_counter + 1
+                  "class_one_arg: a=#{a}"
+                end
+                memo_wise self: :one_arg
+              end
+            end
+
+            it "resets memoization independently" do
+              instance = class_with_memo.new
+              expect(Array.new(4) { instance.one_arg(1) }).to all eq("instance_one_arg: a=1")
+              expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
+
+              class_with_memo.reset_memo_wise(:one_arg)
+
+              expect(Array.new(4) { instance.one_arg(1) }).to all eq("instance_one_arg: a=1")
+              expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
+
+              expect(instance.instance_one_arg_counter).to eq 1 # Never reset, so only incremented once.
+              expect(class_with_memo.class_one_arg_counter).to eq 2 # Once initially and once after resetting.
+
+              instance.reset_memo_wise(:one_arg)
+
+              expect(Array.new(4) { instance.one_arg(1) }).to all eq("instance_one_arg: a=1")
+              expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
+
+              expect(instance.instance_one_arg_counter).to eq 2 # Once initially and once after resetting.
+              expect(class_with_memo.class_one_arg_counter).to eq 2 # Once initially and once after resetting.
+            end
+          end
+        end
+
         context "when defined with scope 'class << self'" do
           include_context "with context for class methods via scope 'class << self'"
 


### PR DESCRIPTION
This commit fixes a variety of bugs that occurred when a
parent class uses `MemoWise` and a child class inherits
from it and tries to use the memoized methods.

Fixes #228

**Before merging:**

- [ ] ~Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR~
- [x] If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)
