### PR TITLE
Switch heredocs from <<- to <<~

### DIFF
--- a/benchmarks/benchmarks.rb
+++ b/benchmarks/benchmarks.rb
@@ -63,8 +63,7 @@ BENCHMARK_GEMS = [
 # Use metaprogramming to ensure that each class is created in exactly the
 # the same way.
 BENCHMARK_GEMS.each do |benchmark_gem|
-  # rubocop:disable Security/Eval
-  eval <<-CLASS, binding, __FILE__, __LINE__ + 1
+  eval <<~HEREDOC, binding, __FILE__, __LINE__ + 1 # rubocop:disable Security/Eval
     # For these methods, we alternately return truthy and falsey values in
     # order to benchmark memoization when the result of a method is falsey.
     #
@@ -125,8 +124,7 @@ BENCHMARK_GEMS.each do |benchmark_gem|
       end
       #{benchmark_gem.memoization_method} :positional_splat_keyword_and_double_splat_args
     end
-  CLASS
-  # rubocop:enable Security/Eval
+  HEREDOC
 end
 
 # We pre-create argument lists for our memoized methods with arguments, so that

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -56,7 +56,7 @@ module MemoWise
   # :nocov:
   all_args = RUBY_VERSION < "2.7" ? "*" : "..."
   # :nocov:
-  class_eval <<-END_OF_METHOD, __FILE__, __LINE__ + 1
+  class_eval <<~HEREDOC, __FILE__, __LINE__ + 1
     # On Ruby 2.7 or greater:
     #
     # def initialize(...)
@@ -75,7 +75,7 @@ module MemoWise
       MemoWise::InternalAPI.create_memo_wise_state!(self)
       super
     end
-  END_OF_METHOD
+  HEREDOC
 
   # @private
   #
@@ -159,12 +159,12 @@ module MemoWise
         if klass.singleton_class?
           # This ensures that a memoized method defined on a parent class can
           # still be used in a child class.
-          klass.module_eval <<-END_OF_METHOD, __FILE__, __LINE__ + 1
+          klass.module_eval <<~HEREDOC, __FILE__, __LINE__ + 1
             def inherited(subclass)
               super
               MemoWise::InternalAPI.create_memo_wise_state!(subclass)
             end
-          END_OF_METHOD
+          HEREDOC
         end
 
         raise ArgumentError, "#{method_name.inspect} must be a Symbol" unless method_name.is_a?(Symbol)
@@ -184,7 +184,7 @@ module MemoWise
         when MemoWise::InternalAPI::NONE
           # Zero-arg methods can use simpler/more performant logic because the
           # hash key is just the method name.
-          klass.module_eval <<-END_OF_METHOD, __FILE__, __LINE__ + 1
+          klass.module_eval <<~HEREDOC, __FILE__, __LINE__ + 1
             def #{method_name}
               if @_memo_wise_sentinels[#{index}]
                 @_memo_wise[#{index}]
@@ -194,11 +194,11 @@ module MemoWise
                 ret
               end
             end
-          END_OF_METHOD
+          HEREDOC
         when MemoWise::InternalAPI::ONE_REQUIRED_POSITIONAL, MemoWise::InternalAPI::ONE_REQUIRED_KEYWORD
           key = method.parameters.first.last
 
-          klass.module_eval <<-END_OF_METHOD, __FILE__, __LINE__ + 1
+          klass.module_eval <<~HEREDOC, __FILE__, __LINE__ + 1
             def #{method_name}(#{MemoWise::InternalAPI.args_str(method)})
               _memo_wise_hash = (@_memo_wise[#{index}] ||= {})
               _memo_wise_output = _memo_wise_hash[#{key}]
@@ -208,7 +208,7 @@ module MemoWise
                 _memo_wise_hash[#{key}] = #{original_memo_wised_name}(#{MemoWise::InternalAPI.call_str(method)})
               end
             end
-          END_OF_METHOD
+          HEREDOC
         # MemoWise::InternalAPI::MULTIPLE_REQUIRED, MemoWise::InternalAPI::SPLAT,
         # MemoWise::InternalAPI::DOUBLE_SPLAT, MemoWise::InternalAPI::SPLAT_AND_DOUBLE_SPLAT
         else
@@ -224,7 +224,7 @@ module MemoWise
           # consistent performance. In general, this should still be faster for
           # truthy results because `Hash#[]` generally performs hash lookups
           # faster than `Hash#fetch`.
-          klass.module_eval <<-END_OF_METHOD, __FILE__, __LINE__ + 1
+          klass.module_eval <<~HEREDOC, __FILE__, __LINE__ + 1
             def #{method_name}(#{MemoWise::InternalAPI.args_str(method)})
               _memo_wise_hash = (@_memo_wise[#{index}] ||= {})
               _memo_wise_key = #{MemoWise::InternalAPI.key_str(method)}
@@ -235,7 +235,7 @@ module MemoWise
                 _memo_wise_hash[_memo_wise_key] = #{original_memo_wised_name}(#{MemoWise::InternalAPI.call_str(method)})
               end
             end
-          END_OF_METHOD
+          HEREDOC
         end
 
         klass.send(visibility, method_name)

--- a/spec/support/define_methods_for_testing_memo_wise.rb
+++ b/spec/support/define_methods_for_testing_memo_wise.rb
@@ -33,7 +33,7 @@ module DefineMethodsForTestingMemoWise
     self_kw_arg = via == :self_dot ? "self: " : ""
     self_class_method = via == :self_dot ? "_class_method" : ""
 
-    target.module_eval <<~END_OF_METHODS, __FILE__, __LINE__ + 1
+    target.module_eval <<~HEREDOC, __FILE__, __LINE__ + 1
       def #{self_prefix}no_args_counter
         @no_args_counter || 0
       end
@@ -237,6 +237,6 @@ module DefineMethodsForTestingMemoWise
         yield
       end
       memo_wise #{self_kw_arg}:implicit_block_method
-    END_OF_METHODS
+    HEREDOC
   end
 end


### PR DESCRIPTION
This commit also changes the heredoc closing
signifier to `HEREDOC` everywhere, for clarity.

Closes #232

**Before merging:**

- [ ] ~Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR~
- [ ] ~If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)~
