### PR TITLE
Fix multiple inheritance-related bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+- Fix several bugs related to classes inheriting memoized methods
+  from multiple modules or a parent class ([#241](https://github.com/panorama-ed/memo_wise/pull/241))
 
 ## [1.3.0] - 2021-11-22
 

--- a/README.md
+++ b/README.md
@@ -118,15 +118,15 @@ Results using Ruby 3.0.3:
 
 |Method arguments|`Dry::Core`\* (0.7.1)|`Memery` (1.4.0)|
 |--|--|--|
-|`()` (none)|1.42x|18.07x|
-|`(a)`|2.31x|11.30x|
-|`(a, b)`|0.46x|2.04x|
-|`(a:)`|2.15x|20.31x|
-|`(a:, b:)`|0.48x|4.25x|
-|`(a, b:)`|0.47x|4.05x|
-|`(a, *args)`|0.87x|1.96x|
-|`(a:, **kwargs)`|0.79x|3.02x|
-|`(a, *args, b:, **kwargs)`|0.60x|1.57x|
+|`()` (none)|1.36x|19.42x|
+|`(a)`|2.47x|11.39x|
+|`(a, b)`|0.44x|2.16x|
+|`(a:)`|2.30x|22.89x|
+|`(a:, b:)`|0.47x|4.54x|
+|`(a, b:)`|0.47x|4.33x|
+|`(a, *args)`|0.83x|2.09x|
+|`(a:, **kwargs)`|0.76x|2.85x|
+|`(a, *args, b:, **kwargs)`|0.61x|1.55x|
 
 \* `Dry::Core`
 [may cause incorrect behavior caused by hash collisions](https://github.com/dry-rb/dry-core/issues/63).
@@ -135,15 +135,15 @@ Results using Ruby 2.7.5 (because these gems raise errors in Ruby 3.x):
 
 |Method arguments|`DDMemoize` (1.0.0)|`Memoist` (0.16.2)|`Memoized` (1.0.2)|`Memoizer` (1.0.3)|
 |--|--|--|--|--|
-|`()` (none)|37.00x|3.49x|1.72x|4.33x|
-|`(a)`|29.10x|19.52x|14.74x|16.96x|
-|`(a, b)`|3.29x|2.34x|1.85x|2.04x|
-|`(a:)`|39.39x|31.54x|26.94x|28.40x|
-|`(a:, b:)`|5.34x|4.43x|3.89x|4.06x|
-|`(a, b:)`|4.99x|4.13x|3.56x|3.74x|
-|`(a, *args)`|3.19x|2.30x|1.95x|1.99x|
-|`(a:, **kwargs)`|2.91x|2.44x|2.11x|2.23x|
-|`(a, *args, b:, **kwargs)`|2.11x|1.78x|1.66x|1.65x|
+|`()` (none)|36.84x|3.56x|1.68x|4.19x|
+|`(a)`|27.50x|18.85x|13.97x|15.99x|
+|`(a, b)`|3.27x|2.34x|1.85x|2.05x|
+|`(a:)`|37.22x|30.09x|25.57x|27.28x|
+|`(a:, b:)`|5.25x|4.38x|3.80x|4.02x|
+|`(a, b:)`|5.08x|4.15x|3.56x|3.78x|
+|`(a, *args)`|3.17x|2.32x|1.96x|2.01x|
+|`(a:, **kwargs)`|2.87x|2.42x|2.10x|2.21x|
+|`(a, *args, b:, **kwargs)`|2.05x|1.76x|1.63x|1.65x|
 
 You can run benchmarks yourself with:
 

--- a/spec/memo_wise/internal_api_spec.rb
+++ b/spec/memo_wise/internal_api_spec.rb
@@ -108,8 +108,8 @@ RSpec.describe MemoWise::InternalAPI do
     end
   end
 
-  describe "#method_visibility" do
-    subject { described_class.new(String).method_visibility(method_name) }
+  describe ".method_visibility" do
+    subject { described_class.method_visibility(String, method_name) }
 
     context "when method_name is not a method on klass" do
       let(:method_name) { :not_a_method }

--- a/spec/support/shared_context_for_class_methods_via_class_scope.rb
+++ b/spec/support/shared_context_for_class_methods_via_class_scope.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.shared_context "with context for class methods via scope 'class << self'" do
-  # NOTE: This use of `before(:all)` is a performance optimization that shaves
-  # minutes off of our test suite, especially in older versions of Ruby.
-  before(:all) do
-    @_class_with_memo = Class.new do
+  let(:class_with_memo) do
+    Class.new do
       class << self
         prepend MemoWise
 
@@ -60,18 +58,5 @@ RSpec.shared_context "with context for class methods via scope 'class << self'" 
         "instance_with_positional_args: a=#{a}, b=#{b}"
       end
     end
-  end
-
-  let(:class_with_memo) do
-    # Because we now have shared state between tests, we need to ensure that we
-    # reset memo_wise, as well as any test state, for each individual test.
-    # rubocop:disable RSpec/InstanceVariable
-    @_class_with_memo.reset_memo_wise
-    @_class_with_memo.instance_variables.each do |var|
-      # reset test method counters from DefineMethodsForTestingMemoWise
-      @_class_with_memo.instance_variable_set(var, 0) if @_class_with_memo.instance_variable_get(var).is_a?(Integer)
-    end
-    @_class_with_memo
-    # rubocop:enable RSpec/InstanceVariable
   end
 end

--- a/spec/support/shared_context_for_module_methods_via_class_scope.rb
+++ b/spec/support/shared_context_for_module_methods_via_class_scope.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.shared_context "with context for module methods via scope 'class << self'" do
-  # NOTE: This use of `before(:all)` is a performance optimization that shaves
-  # minutes off of our test suite, especially in older versions of Ruby.
-  before(:all) do
-    @_module_with_memo = Module.new do
+  let(:module_with_memo) do
+    Module.new do
       class << self
         prepend MemoWise
 
@@ -15,6 +13,4 @@ RSpec.shared_context "with context for module methods via scope 'class << self'"
       end
     end
   end
-
-  let(:module_with_memo) { @_module_with_memo } # rubocop:disable RSpec/InstanceVariable
 end

--- a/spec/thread_safety_spec.rb
+++ b/spec/thread_safety_spec.rb
@@ -10,7 +10,11 @@ RSpec.describe "thread safety" do # rubocop:disable RSpec/DescribeClass
       end
     end
 
-    let(:class_with_memo) do
+    # To test thread safety of the `module_eval` calls introduced in PR #241
+    # which redefine methods on their first call, we make a new class on each
+    # loop of the `check_repeatedly` above. If we remove the method redefinition
+    # code paths in MemoWise.prepended, then we can return this to being `let`.
+    def class_with_memo
       Class.new do
         prepend MemoWise
 


### PR DESCRIPTION
This commit fixes several bugs related to inheritance by
delaying the calculation of the index used to store memoized
method results until the method itself is called. This incurs
a slight performance penalty the first time a method is called.

Closes #238
Closes #239

**Before merging:**

- [ ] Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR
- [ ] If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)
