### PR TITLE
Revert internal data structure to simple hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+- Switch to a simpler internal data structure to fix several classes of bugs
+  that the previous few versions were unable to sufficiently address
 
 ## [1.4.0] - 2021-12-10
 

--- a/README.md
+++ b/README.md
@@ -118,15 +118,15 @@ Results using Ruby 3.0.3:
 
 |Method arguments|`Dry::Core`\* (0.7.1)|`Memery` (1.4.0)|
 |--|--|--|
-|`()` (none)|1.36x|19.42x|
-|`(a)`|2.47x|11.39x|
-|`(a, b)`|0.44x|2.16x|
-|`(a:)`|2.30x|22.89x|
-|`(a:, b:)`|0.47x|4.54x|
-|`(a, b:)`|0.47x|4.33x|
-|`(a, *args)`|0.83x|2.09x|
-|`(a:, **kwargs)`|0.76x|2.85x|
-|`(a, *args, b:, **kwargs)`|0.61x|1.55x|
+|`()` (none)|1.29x|17.21x|
+|`(a)`|2.33x|11.03x|
+|`(a, b)`|0.44x|2.00x|
+|`(a:)`|2.06x|21.20x|
+|`(a:, b:)`|0.47x|4.40x|
+|`(a, b:)`|0.47x|4.27x|
+|`(a, *args)`|0.86x|1.95x|
+|`(a:, **kwargs)`|0.77x|3.01x|
+|`(a, *args, b:, **kwargs)`|0.59x|1.60x|
 
 \* `Dry::Core`
 [may cause incorrect behavior caused by hash collisions](https://github.com/dry-rb/dry-core/issues/63).
@@ -135,15 +135,15 @@ Results using Ruby 2.7.5 (because these gems raise errors in Ruby 3.x):
 
 |Method arguments|`DDMemoize` (1.0.0)|`Memoist` (0.16.2)|`Memoized` (1.0.2)|`Memoizer` (1.0.3)|
 |--|--|--|--|--|
-|`()` (none)|36.84x|3.56x|1.68x|4.19x|
-|`(a)`|27.50x|18.85x|13.97x|15.99x|
-|`(a, b)`|3.27x|2.34x|1.85x|2.05x|
-|`(a:)`|37.22x|30.09x|25.57x|27.28x|
-|`(a:, b:)`|5.25x|4.38x|3.80x|4.02x|
-|`(a, b:)`|5.08x|4.15x|3.56x|3.78x|
-|`(a, *args)`|3.17x|2.32x|1.96x|2.01x|
-|`(a:, **kwargs)`|2.87x|2.42x|2.10x|2.21x|
-|`(a, *args, b:, **kwargs)`|2.05x|1.76x|1.63x|1.65x|
+|`()` (none)|31.13x|3.12x|1.51x|3.57x|
+|`(a)`|23.95x|16.52x|12.11x|14.00x|
+|`(a, b)`|3.18x|2.31x|1.82x|2.00x|
+|`(a:)`|33.55x|27.09x|23.21x|24.68x|
+|`(a:, b:)`|5.20x|4.28x|3.82x|3.99x|
+|`(a, b:)`|4.96x|4.09x|3.57x|3.76x|
+|`(a, *args)`|3.10x|2.32x|1.95x|1.97x|
+|`(a:, **kwargs)`|2.89x|2.43x|2.12x|2.25x|
+|`(a, *args, b:, **kwargs)`|2.05x|1.77x|1.63x|1.65x|
 
 You can run benchmarks yourself with:
 

--- a/benchmarks/benchmarks.rb
+++ b/benchmarks/benchmarks.rb
@@ -76,14 +76,6 @@ BENCHMARK_GEMS.each do |benchmark_gem|
       end
       #{benchmark_gem.memoization_method} :no_args
 
-      # For the no_args case, we can't depend on arguments to alternate between
-      # returning truthy and falsey values, so instead make two separate
-      # no_args methods
-      def no_args_falsey
-        nil
-      end
-      #{benchmark_gem.memoization_method} :no_args_falsey
-
       def one_positional_arg(a)
         100 if a.positive?
       end
@@ -132,9 +124,7 @@ end
 #
 # NOTE: The proportion of falsey results is 1/N_UNIQUE_ARGUMENTS (because for
 # the methods with arguments we are truthy for all but the first unique argument
-# set, and for zero-arity methods we manually execute `no_args` N_TRUTHY_RESULTS
-# times per each execution of `no_args_falsey`). This number was selected as the
-# lowest number such that this logic:
+# set). This number was selected as the lowest number such that this logic:
 #
 #   output = hash[key]
 #   if output || hash.key?(key)
@@ -165,12 +155,10 @@ N_RESULT_DECIMAL_DIGITS = 2
 # result value, so our benchmark only tests memoized retrieval time.
 benchmark_lambdas = [
   lambda do |x, instance, benchmark_gem|
-    instance.no_args_falsey
     instance.no_args
 
     x.report("#{benchmark_gem.benchmark_name}: ()") do
-      instance.no_args_falsey
-      N_TRUTHY_RESULTS.times { instance.no_args }
+      instance.no_args
     end
   end,
   lambda do |x, instance, benchmark_gem|

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -180,72 +180,26 @@ module MemoWise
 
         case method_arguments
         when MemoWise::InternalAPI::NONE
-          # Zero-arg methods can use simpler/more performant logic because the
-          # hash key is just the method name.
-          klass.send(:define_method, method_name) do # Ruby 2.4's `define_method` is private in some cases
-            index = MemoWise::InternalAPI.index(self, method_name)
-            klass.module_eval <<~HEREDOC, __FILE__, __LINE__ + 1
-              def #{method_name}
-                if @_memo_wise_sentinels[#{index}]
-                  @_memo_wise[#{index}]
-                else
-                  ret = @_memo_wise[#{index}] = #{original_memo_wised_name}
-                  @_memo_wise_sentinels[#{index}] = true
-                  ret
-                end
+          klass.module_eval <<~HEREDOC, __FILE__, __LINE__ + 1
+            def #{method_name}
+              @_memo_wise.fetch(:#{method_name}) do
+                @_memo_wise[:#{method_name}] = #{original_memo_wised_name}
               end
-            HEREDOC
-
-            klass.send(visibility, method_name)
-            send(method_name)
-          end
+            end
+          HEREDOC
         when MemoWise::InternalAPI::ONE_REQUIRED_POSITIONAL, MemoWise::InternalAPI::ONE_REQUIRED_KEYWORD
           key = method.parameters.first.last
-          # NOTE: Ruby 2.6 and below, and TruffleRuby 3.0, break when we use
-          # `define_method(...) do |*args, **kwargs|`. Instead we must use the
-          # simpler `|*args|` pattern. We can't just do this always though
-          # because Ruby 2.7 and above require `|*args, **kwargs|` to work
-          # correctly.
-          # See: https://blog.saeloun.com/2019/10/07/ruby-2-7-keyword-arguments-redesign.html#ruby-26
-          # :nocov:
-          if RUBY_VERSION < "2.7" || RUBY_ENGINE == "truffleruby"
-            klass.send(:define_method, method_name) do |*args| # Ruby 2.4's `define_method` is private in some cases
-              index = MemoWise::InternalAPI.index(self, method_name)
-              klass.module_eval <<~HEREDOC, __FILE__, __LINE__ + 1
-                def #{method_name}(#{MemoWise::InternalAPI.args_str(method)})
-                  _memo_wise_hash = (@_memo_wise[#{index}] ||= {})
-                  _memo_wise_output = _memo_wise_hash[#{key}]
-                  if _memo_wise_output || _memo_wise_hash.key?(#{key})
-                    _memo_wise_output
-                  else
-                    _memo_wise_hash[#{key}] = #{original_memo_wised_name}(#{MemoWise::InternalAPI.call_str(method)})
-                  end
-                end
-              HEREDOC
-
-              klass.send(visibility, method_name)
-              send(method_name, *args)
+          klass.module_eval <<~HEREDOC, __FILE__, __LINE__ + 1
+            def #{method_name}(#{MemoWise::InternalAPI.args_str(method)})
+              _memo_wise_hash = (@_memo_wise[:#{method_name}] ||= {})
+              _memo_wise_output = _memo_wise_hash[#{key}]
+              if _memo_wise_output || _memo_wise_hash.key?(#{key})
+                _memo_wise_output
+              else
+                _memo_wise_hash[#{key}] = #{original_memo_wised_name}(#{MemoWise::InternalAPI.call_str(method)})
+              end
             end
-            # :nocov:
-          else
-            klass.define_method(method_name) do |*args, **kwargs|
-              index = MemoWise::InternalAPI.index(self, method_name)
-              klass.module_eval <<~HEREDOC, __FILE__, __LINE__ + 1
-                def #{method_name}(#{MemoWise::InternalAPI.args_str(method)})
-                  _memo_wise_hash = (@_memo_wise[#{index}] ||= {})
-                  _memo_wise_output = _memo_wise_hash[#{key}]
-                  if _memo_wise_output || _memo_wise_hash.key?(#{key})
-                    _memo_wise_output
-                  else
-                    _memo_wise_hash[#{key}] = #{original_memo_wised_name}(#{MemoWise::InternalAPI.call_str(method)})
-                  end
-                end
-              HEREDOC
-
-              klass.send(visibility, method_name)
-              send(method_name, *args, **kwargs)
-            end
-          end
+          HEREDOC
         # MemoWise::InternalAPI::MULTIPLE_REQUIRED, MemoWise::InternalAPI::SPLAT,
         # MemoWise::InternalAPI::DOUBLE_SPLAT, MemoWise::InternalAPI::SPLAT_AND_DOUBLE_SPLAT
         else
@@ -261,54 +215,18 @@ module MemoWise
           # consistent performance. In general, this should still be faster for
           # truthy results because `Hash#[]` generally performs hash lookups
           # faster than `Hash#fetch`.
-          #
-          # NOTE: Ruby 2.6 and below, and TruffleRuby 3.0, break when we use
-          # `define_method(...) do |*args, **kwargs|`. Instead we must use the
-          # simpler `|*args|` pattern. We can't just do this always though
-          # because Ruby 2.7 and above require `|*args, **kwargs|` to work
-          # correctly.
-          # See: https://blog.saeloun.com/2019/10/07/ruby-2-7-keyword-arguments-redesign.html#ruby-26
-          # :nocov:
-          if RUBY_VERSION < "2.7" || RUBY_ENGINE == "truffleruby"
-            klass.send(:define_method, method_name) do |*args| # Ruby 2.4's `define_method` is private in some cases
-              index = MemoWise::InternalAPI.index(self, method_name)
-              klass.module_eval <<~HEREDOC, __FILE__, __LINE__ + 1
-                def #{method_name}(#{MemoWise::InternalAPI.args_str(method)})
-                  _memo_wise_hash = (@_memo_wise[#{index}] ||= {})
-                  _memo_wise_key = #{MemoWise::InternalAPI.key_str(method)}
-                  _memo_wise_output = _memo_wise_hash[_memo_wise_key]
-                  if _memo_wise_output || _memo_wise_hash.key?(_memo_wise_key)
-                    _memo_wise_output
-                  else
-                    _memo_wise_hash[_memo_wise_key] = #{original_memo_wised_name}(#{MemoWise::InternalAPI.call_str(method)})
-                  end
-                end
-              HEREDOC
-
-              klass.send(visibility, method_name)
-              send(method_name, *args)
+          klass.module_eval <<~HEREDOC, __FILE__, __LINE__ + 1
+            def #{method_name}(#{MemoWise::InternalAPI.args_str(method)})
+              _memo_wise_hash = (@_memo_wise[:#{method_name}] ||= {})
+              _memo_wise_key = #{MemoWise::InternalAPI.key_str(method)}
+              _memo_wise_output = _memo_wise_hash[_memo_wise_key]
+              if _memo_wise_output || _memo_wise_hash.key?(_memo_wise_key)
+                _memo_wise_output
+              else
+                _memo_wise_hash[_memo_wise_key] = #{original_memo_wised_name}(#{MemoWise::InternalAPI.call_str(method)})
+              end
             end
-            # :nocov:
-          else # Ruby 2.7 and above break with (*args)
-            klass.define_method(method_name) do |*args, **kwargs|
-              index = MemoWise::InternalAPI.index(self, method_name)
-              klass.module_eval <<~HEREDOC, __FILE__, __LINE__ + 1
-                def #{method_name}(#{MemoWise::InternalAPI.args_str(method)})
-                  _memo_wise_hash = (@_memo_wise[#{index}] ||= {})
-                  _memo_wise_key = #{MemoWise::InternalAPI.key_str(method)}
-                  _memo_wise_output = _memo_wise_hash[_memo_wise_key]
-                  if _memo_wise_output || _memo_wise_hash.key?(_memo_wise_key)
-                    _memo_wise_output
-                  else
-                    _memo_wise_hash[_memo_wise_key] = #{original_memo_wised_name}(#{MemoWise::InternalAPI.call_str(method)})
-                  end
-                end
-              HEREDOC
-
-              klass.send(visibility, method_name)
-              send(method_name, *args, **kwargs)
-            end
-          end
+          HEREDOC
         end
 
         klass.send(visibility, method_name)
@@ -511,21 +429,20 @@ module MemoWise
   #   ex.method_called_times #=> nil
   #
   def preset_memo_wise(method_name, *args, **kwargs)
+    raise ArgumentError, "#{method_name.inspect} must be a Symbol" unless method_name.is_a?(Symbol)
     raise ArgumentError, "Pass a block as the value to preset for #{method_name}, #{args}" unless block_given?
 
     MemoWise::InternalAPI.validate_memo_wised!(self, method_name)
 
     method = method(MemoWise::InternalAPI.original_memo_wised_name(method_name))
     method_arguments = MemoWise::InternalAPI.method_arguments(method)
-    index = MemoWise::InternalAPI.index(self, method_name)
 
     if method_arguments == MemoWise::InternalAPI::NONE
-      @_memo_wise_sentinels[index] = true
-      @_memo_wise[index] = yield
+      @_memo_wise[method_name] = yield
       return
     end
 
-    hash = (@_memo_wise[index] ||= {})
+    hash = (@_memo_wise[method_name] ||= {})
 
     case method_arguments
     when MemoWise::InternalAPI::ONE_REQUIRED_POSITIONAL then hash[args.first] = yield
@@ -613,7 +530,6 @@ module MemoWise
       raise ArgumentError, "Provided kwargs when method_name = nil" unless kwargs.empty?
 
       @_memo_wise.clear
-      @_memo_wise_sentinels.clear
       return
     end
 
@@ -624,49 +540,25 @@ module MemoWise
 
     method = method(MemoWise::InternalAPI.original_memo_wised_name(method_name))
     method_arguments = MemoWise::InternalAPI.method_arguments(method)
-    index = MemoWise::InternalAPI.index(self, method_name)
+
+    # method_name == MemoWise::InternalAPI::NONE will be covered by this case.
+    @_memo_wise.delete(method_name) if args.empty? && kwargs.empty?
+    method_hash = @_memo_wise[method_name]
 
     case method_arguments
-    when MemoWise::InternalAPI::NONE
-      @_memo_wise_sentinels[index] = nil
-      @_memo_wise[index] = nil
-    when MemoWise::InternalAPI::ONE_REQUIRED_POSITIONAL
-      if args.empty?
-        @_memo_wise[index]&.clear
-      else
-        @_memo_wise[index]&.delete(args.first)
-      end
-    when MemoWise::InternalAPI::ONE_REQUIRED_KEYWORD
-      if kwargs.empty?
-        @_memo_wise[index]&.clear
-      else
-        @_memo_wise[index]&.delete(kwargs.first.last)
-      end
-    when MemoWise::InternalAPI::SPLAT
-      if args.empty?
-        @_memo_wise[index]&.clear
-      else
-        @_memo_wise[index]&.delete(args)
-      end
-    when MemoWise::InternalAPI::DOUBLE_SPLAT
-      if kwargs.empty?
-        @_memo_wise[index]&.clear
-      else
-        @_memo_wise[index]&.delete(kwargs)
-      end
+    when MemoWise::InternalAPI::ONE_REQUIRED_POSITIONAL then method_hash&.delete(args.first)
+    when MemoWise::InternalAPI::ONE_REQUIRED_KEYWORD then method_hash&.delete(kwargs.first.last)
+    when MemoWise::InternalAPI::SPLAT then method_hash&.delete(args)
+    when MemoWise::InternalAPI::DOUBLE_SPLAT then method_hash&.delete(kwargs)
     else # MemoWise::InternalAPI::MULTIPLE_REQUIRED, MemoWise::InternalAPI::SPLAT_AND_DOUBLE_SPLAT
-      if args.empty? && kwargs.empty?
-        @_memo_wise[index]&.clear
-      else
-        key = if method_arguments == MemoWise::InternalAPI::SPLAT_AND_DOUBLE_SPLAT
-                [args, kwargs]
-              else
-                method.parameters.map.with_index do |(type, name), i|
-                  type == :req ? args[i] : kwargs[name] # rubocop:disable Metrics/BlockNesting
-                end
+      key = if method_arguments == MemoWise::InternalAPI::SPLAT_AND_DOUBLE_SPLAT
+              [args, kwargs]
+            else
+              method.parameters.map.with_index do |(type, name), i|
+                type == :req ? args[i] : kwargs[name]
               end
-        @_memo_wise[index]&.delete(key)
-      end
+            end
+      method_hash&.delete(key)
     end
   end
 end

--- a/spec/preset_memo_wise_spec.rb
+++ b/spec/preset_memo_wise_spec.rb
@@ -330,6 +330,10 @@ RSpec.describe MemoWise do
         expect(instance2.no_args_counter).to eq(1)
       end
 
+      context "when the name of the method is not a symbol" do
+        it { expect { instance.preset_memo_wise("no_args") { nil } }.to raise_error(ArgumentError) }
+      end
+
       context "when the method to preset memoization for is not memoized" do
         it do
           expect { instance.preset_memo_wise(:unmemoized_method) { nil } }.

--- a/spec/support/check_repeatedly.rb
+++ b/spec/support/check_repeatedly.rb
@@ -15,7 +15,7 @@
 #   return if this returns `true`.
 #
 # @param up_to_max_secs [Numeric]
-#   Max number of seconds to run, default: 1.
+#   Max number of seconds to run, default: 15.
 #
 # @yieldreturn [Object]
 #   Return value of given block is checked against given condition on each
@@ -23,7 +23,7 @@
 #
 # @return [Object]
 #   Returns the final return value of the given block.
-def check_repeatedly(condition_proc:, up_to_max_secs: 1.0)
+def check_repeatedly(condition_proc:, up_to_max_secs: 15.0)
   time_max = Time.now.utc + up_to_max_secs
 
   loop do

--- a/spec/thread_safety_spec.rb
+++ b/spec/thread_safety_spec.rb
@@ -10,10 +10,7 @@ RSpec.describe "thread safety" do # rubocop:disable RSpec/DescribeClass
       end
     end
 
-    # To test thread safety of the `module_eval` calls introduced in PR #241
-    # which redefine methods on their first call, we make a new class on each
-    # loop of the `check_repeatedly` above. If we remove the method redefinition
-    # code paths in MemoWise.prepended, then we can return this to being `let`.
+    # Using `def` here makes race conditions far more likely than `let`.
     def class_with_memo
       Class.new do
         prepend MemoWise


### PR DESCRIPTION
Previous versions of `MemoWise` used an array as the
internal cache data structure, where each memoized method
uses a unique array index. However, complex inheritance
structures make it easy to have multiple methods accidentally
share the same array index on the same object, resulting
in nondeterministic and incorrect behavior.

While we may explore that optimization again in the future,
for the time being we are switching to a hash data structure
keyed on method name, which is safer because two methods
cannot share the same name in Ruby.

Fixes #251 

**Before merging:**

- [ ] Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR
- [x] If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)
