### PR TITLE
Change year to 2022

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020-2021 Panorama Education
+Copyright (c) 2020-2022 Panorama Education
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Annual year change PR to adjust references to the current year.

At this time, the only change is in the MIT License file (c) line,
in LICENSE.txt

Let's merge on Jan 1 2022 to celebrate the New Year!