### PR TITLE
Fix Codecov uploader

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,13 @@ jobs:
 
     - run: bundle exec rspec
 
+    - uses: codecov/codecov-action@v2
+      with:
+        files: ./coverage/coverage.xml
+        fail_ci_if_error: true # optional (default = false)
+        verbose: true # optional (default = false)
+      if: matrix.ruby == 3.1
+
     - run: bundle exec rubocop
       if: matrix.ruby == 3.1
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,13 @@ end
 
 # Excluded from CI except on latest MRI Ruby, to reduce compatibility burden
 group :checks do
-  gem "codecov"
   gem "panolint", github: "panorama-ed/panolint", branch: "main"
+
+  # Simplecov to generate coverage info
+  gem "simplecov", require: false
+
+  # Simplecov-cobertura to generate an xml coverage file to upload to Codecov
+  gem "simplecov-cobertura", require: false
 end
 
 # Excluded from CI except on latest MRI Ruby, to reduce compatibility burden

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,8 +28,6 @@ GEM
     ansi (1.5.0)
     ast (2.4.2)
     brakeman (5.1.2)
-    codecov (0.6.0)
-      simplecov (>= 0.15, < 0.22)
     concurrent-ruby (1.1.9)
     diff-lcs (1.5.0)
     docile (1.3.5)
@@ -89,6 +87,8 @@ GEM
     simplecov (0.18.5)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
+    simplecov-cobertura (1.4.2)
+      simplecov (~> 0.8)
     simplecov-html (0.12.3)
     slop (3.6.0)
     tzinfo (2.0.4)
@@ -107,16 +107,17 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  codecov
   dokaz
   memo_wise!
   panolint!
   rake
   redcarpet (~> 3.5)
   rspec (~> 3.11)
+  simplecov
+  simplecov-cobertura
   values (~> 1)
   yard (~> 0.9)
   yard-doctest (~> 0.1)
 
 BUNDLED WITH
-   2.2.32
+   2.3.8

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,8 @@
 
 # Simplecov needs to be loaded before we require `memo_wise` in order to
 # properly track all memo_wise files
-if Gem.loaded_specs.key?("codecov")
-  require "codecov"
-  require "simplecov"
+if Gem.loaded_specs.key?("simplecov")
+  require "simplecov-cobertura"
 
   SimpleCov.start do
     enable_coverage :branch
@@ -12,7 +11,7 @@ if Gem.loaded_specs.key?("codecov")
   end
 
   SimpleCov.formatter = if ENV["CI"] == "true"
-                          SimpleCov::Formatter::Codecov
+                          SimpleCov::Formatter::CoberturaFormatter
                         else
                           # Writes coverage file into coverage/index.html
                           # when run outside of CI for local development


### PR DESCRIPTION
The codecov gem has been [deprecated], and since Feb 1 2022 it
[errors] in CI.

This PR carries out the recommended [migration] steps to generate
XML using the simplecov-cobertura gem, and them add the Github Action
[uploader] to send that data to Codecov

[deprecated]: https://github.com/codecov/codecov-ruby
[errors]: https://github.com/panorama-ed/memo_wise/runs/5394171013?check_suite_focus=true
[migration]: https://docs.codecov.com/docs/deprecated-uploader-migration-guide#ruby-uploader
[uploader]: https://github.com/marketplace/actions/codecov

