### PR TITLE
Use nested hashes for multiple required arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-Nothing yet!
+### Updated
+
+- Optimize memoized lookups for methods with multiple required arguments
 
 ## [1.6.0] - 2022-01-24
 

--- a/README.md
+++ b/README.md
@@ -115,19 +115,19 @@ For more usage details, see our detailed [documentation](#documentation).
 
 Benchmarks are run in GitHub Actions, and the tables below are updated with every code change. **Values >1.00x represent how much _slower_ each gem’s memoized value retrieval is than the latest commit of `MemoWise`**, according to [`benchmark-ips`](https://github.com/evanphx/benchmark-ips) (2.9.2).
 
-Results using Ruby 3.1.0:
+Results using Ruby 3.1.1:
 
-|Method arguments|`Dry::Core` (0.7.1)|`Memery` (1.4.0)|
+|Method arguments|`Dry::Core`\* (0.7.1)|`Memery` (1.4.0)|
 |--|--|--|
-|`()` (none)|1.09x|11.80x|
-|`(a)`|1.64x|9.74x|
-|`(a, b)`|0.34x|2.00x|
-|`(a:)`|1.49x|18.84x|
-|`(a:, b:)`|0.35x|4.26x|
-|`(a, b:)`|0.35x|4.18x|
-|`(a, *args)`|0.83x|1.89x|
-|`(a:, **kwargs)`|0.84x|3.30x|
-|`(a, *args, b:, **kwargs)`|0.54x|1.47x|
+|`()` (none)|1.11x|12.24x|
+|`(a)`|1.71x|9.55x|
+|`(a, b)`|1.27x|6.95x|
+|`(a:)`|1.58x|18.25x|
+|`(a:, b:)`|1.19x|13.31x|
+|`(a, b:)`|1.22x|13.29x|
+|`(a, *args)`|0.86x|1.84x|
+|`(a:, **kwargs)`|0.83x|3.15x|
+|`(a, *args, b:, **kwargs)`|0.76x|1.92x|
 
 \* `Dry::Core`
 [may cause incorrect behavior caused by hash collisions](https://github.com/dry-rb/dry-core/issues/63).
@@ -136,15 +136,15 @@ Results using Ruby 2.7.5 (because these gems raise errors in Ruby 3.x):
 
 |Method arguments|`DDMemoize` (1.0.0)|`Memoist` (0.16.2)|`Memoized` (1.0.2)|`Memoizer` (1.0.3)|
 |--|--|--|--|--|
-|`()` (none)|24.30x|2.57x|1.19x|2.98x|
-|`(a)`|21.68x|14.63x|11.13x|12.71x|
-|`(a, b)`|3.18x|2.36x|1.86x|2.06x|
-|`(a:)`|30.62x|24.52x|21.44x|22.61x|
-|`(a:, b:)`|5.25x|4.40x|3.80x|4.04x|
-|`(a, b:)`|4.91x|4.06x|3.55x|3.83x|
-|`(a, *args)`|3.10x|2.31x|1.96x|1.98x|
-|`(a:, **kwargs)`|2.87x|2.40x|2.09x|2.20x|
-|`(a, *args, b:, **kwargs)`|2.08x|1.82x|1.67x|1.70x|
+|`()` (none)|24.22x|2.48x|1.22x|3.08x|
+|`(a)`|20.38x|14.06x|10.85x|12.26x|
+|`(a, b)`|17.48x|12.67x|10.07x|11.32x|
+|`(a:)`|29.72x|24.26x|21.04x|21.72x|
+|`(a:, b:)`|24.17x|20.17x|17.81x|18.85x|
+|`(a, b:)`|24.20x|20.15x|17.51x|18.05x|
+|`(a, *args)`|3.11x|2.23x|1.95x|2.03x|
+|`(a:, **kwargs)`|2.96x|2.46x|2.17x|2.28x|
+|`(a, *args, b:, **kwargs)`|2.17x|1.86x|1.76x|1.76x|
 
 You can run benchmarks yourself with:
 

--- a/lib/memo_wise/internal_api.rb
+++ b/lib/memo_wise/internal_api.rb
@@ -17,8 +17,8 @@ module MemoWise
       #     zero_arg_method_name: :memoized_result,
       #     single_arg_method_name: { arg1 => :memoized_result, ... },
       #
-      #     # Surprisingly, this is faster than a single top-level hash key of: [:multi_arg_method_name, arg1, arg2]
-      #     multi_arg_method_name: { [arg1, arg2] => :memoized_result, ... }
+      #     # This is faster than a single top-level hash key of: [:multi_arg_method_name, arg1, arg2]
+      #     multi_arg_method_name: { arg1 => { arg2 => :memoized_result, ... }, ... }
       #   }
       obj.instance_variable_set(:@_memo_wise, {}) unless obj.instance_variable_defined?(:@_memo_wise)
 
@@ -70,7 +70,6 @@ module MemoWise
       case method_arguments(method)
       when SPLAT then "*args"
       when DOUBLE_SPLAT then "**kwargs"
-      when SPLAT_AND_DOUBLE_SPLAT then "*args, **kwargs"
       when ONE_REQUIRED_POSITIONAL, ONE_REQUIRED_KEYWORD, MULTIPLE_REQUIRED
         method.parameters.map do |type, name|
           "#{name}#{':' if type == :keyreq}"
@@ -105,8 +104,6 @@ module MemoWise
       case method_arguments(method)
       when SPLAT then "args"
       when DOUBLE_SPLAT then "kwargs"
-      when SPLAT_AND_DOUBLE_SPLAT then "[args, kwargs]"
-      when MULTIPLE_REQUIRED then "[#{method.parameters.map(&:last).join(', ')}]"
       else
         raise ArgumentError, "Unexpected arguments for #{method.name}"
       end

--- a/spec/reset_memo_wise_spec.rb
+++ b/spec/reset_memo_wise_spec.rb
@@ -267,8 +267,9 @@ RSpec.describe MemoWise do
             expect { target.reset_memo_wise(:with_optional_positional_and_keyword_args) }.not_to raise_error
           end
 
-          it "doesn't raise an error for methods with optional positional and keyword arguments provided" do
-            expect { target.reset_memo_wise(:with_optional_positional_and_keyword_args, a: 1) }.not_to raise_error
+          it "doesn't raise an error for methods with optional positional and keyword arguments partially provided" do
+            target.with_optional_positional_and_keyword_args(1, b: 1)
+            expect { target.reset_memo_wise(:with_optional_positional_and_keyword_args, 1) }.not_to raise_error
           end
         end
 


### PR DESCRIPTION
This commit optimizes methods with multiple required arguments to use
nested hashes to store the memoized value (so each argument accesses
the next layer in the hash) rather than a single-layer hash with an
array key.

This is more performant because multiple `#hash` calls on simpler
data structures are faster than one `#hash` lookup on all of those
elements within an array, and in addition we avoid the cost of
initializing an array on every lookup.

Closes #244 

**Before merging:**

- [x] Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR
- [x] If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)
