### PR TITLE
Remove broken InchCI badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![Tests](https://github.com/panorama-ed/memo_wise/workflows/Main/badge.svg)](https://github.com/panorama-ed/memo_wise/actions?query=workflow%3AMain)
 [![Code Coverage](https://codecov.io/gh/panorama-ed/memo_wise/branch/main/graph/badge.svg)](https://codecov.io/gh/panorama-ed/memo_wise/branches/main)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](http://rubydoc.info/github/panorama-ed/memo_wise)
-[![Inline docs](http://inch-ci.org/github/panorama-ed/memo_wise.svg?branch=main)](http://inch-ci.org/github/panorama-ed/memo_wise)
 [![Gem Version](https://img.shields.io/gem/v/memo_wise.svg)](https://rubygems.org/gems/memo_wise)
 [![Gem Downloads](https://img.shields.io/gem/dt/memo_wise.svg)](https://rubygems.org/gems/memo_wise)
 


### PR DESCRIPTION
InchCI has been down for many months. Let's remove the dead badge until
such time as this service is back, and we decide it's still valuable.

According to the Wayback Machine, it looks like inch-ci.org hasa been down
[since Nov 10, 2021](https://web.archive.org/web/20211110040521/https://inch-ci.org/) at least.