### PR TITLE
Switch panolint to panolint-ruby

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 inherit_gem:
-  panolint: panolint-rubocop.yml
+  panolint-ruby: panolint-ruby-rubocop.yml
 
 Layout/LineLength:
   Max: 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@ _No breaking changes!_
 
 **Project enhancements:**
 
-- Updated benchmark results in `README.md` to Ruby 3.2.1 and 2.7.7
-- Updated `Dry::Core` gem version to 1.0.0 in benchmarks
-- Updated `Memery` gem version to 1.4.1 in benchmarks
-- Updated `Memoized` gem version to 1.1.1 in benchmarks
+- Switched RuboCop configuration from `panolint` to `panolint-ruby` [[#312]](https://github.com/panorama-ed/memo_wise/pull/312)
+- Updated benchmark results in `README.md` to Ruby 3.2.1 and 2.7.7 [[#297]](https://github.com/panorama-ed/memo_wise/pull/297)
+- Updated `Dry::Core` gem version to 1.0.0 in benchmarks [[#297]](https://github.com/panorama-ed/memo_wise/pull/297)
+- Updated `Memery` gem version to 1.4.1 in benchmarks [[#297]](https://github.com/panorama-ed/memo_wise/pull/297)
+- Updated `Memoized` gem version to 1.1.1 in benchmarks [[#288]](https://github.com/panorama-ed/memo_wise/pull/288)
 - Reorganized `CHANGELOG.md` for improved clarity and completeness
   [[#282](https://github.com/panorama-ed/memo_wise/pull/282)]
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 
 # Excluded from CI except on latest MRI Ruby, to reduce compatibility burden
 group :checks do
-  gem "panolint", github: "panorama-ed/panolint", branch: "main"
+  gem "panolint-ruby", github: "panorama-ed/panolint-ruby", branch: "main"
 
   # Simplecov to generate coverage info
   gem "simplecov", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,12 @@
 GIT
-  remote: https://github.com/panorama-ed/panolint.git
-  revision: bd66f8fb82cb4c8d04ff6b562f65dbef94823e65
+  remote: https://github.com/panorama-ed/panolint-ruby.git
+  revision: a93988ea554177cf0ec9ef636c442f9d3af49a10
   branch: main
   specs:
-    panolint (0.1.7)
-      brakeman (>= 4.8, < 6.0)
-      rubocop (>= 0.83, < 2.0)
-      rubocop-performance (~> 1.5)
-      rubocop-rails (~> 2.5)
-      rubocop-rake (~> 0.5)
-      rubocop-rspec (~> 2.0)
+    panolint-ruby (0)
+      rubocop (= 1.51.0)
+      rubocop-performance (= 1.18.0)
+      rubocop-rspec (= 2.22.0)
 
 PATH
   remote: .
@@ -19,33 +16,23 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4.3)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
     ansi (1.5.0)
     ast (2.4.2)
-    brakeman (5.4.1)
-    concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dokaz (0.0.5)
       ansi
       rouge (~> 4)
       slop (~> 3)
-    i18n (1.12.0)
-      concurrent-ruby (~> 1.0)
     json (2.6.3)
     minitest (5.18.0)
-    parallel (1.22.1)
-    parser (3.2.1.1)
+    parallel (1.23.0)
+    parser (3.2.2.1)
       ast (~> 2.4.1)
-    rack (3.0.6.1)
     rainbow (3.1.1)
     rake (13.0.6)
     redcarpet (3.6.0)
-    regexp_parser (2.7.0)
+    regexp_parser (2.8.0)
     rexml (3.2.5)
     rouge (4.1.0)
     rspec (3.12.0)
@@ -61,32 +48,29 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    rubocop (1.48.1)
+    rubocop (1.51.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.26.0, < 2.0)
+      rubocop-ast (>= 1.28.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.27.0)
+    rubocop-ast (1.28.1)
       parser (>= 3.2.1.0)
-    rubocop-capybara (2.17.1)
+    rubocop-capybara (2.18.0)
       rubocop (~> 1.41)
-    rubocop-performance (1.16.0)
+    rubocop-factory_bot (2.23.1)
+      rubocop (~> 1.33)
+    rubocop-performance (1.18.0)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    rubocop-rails (2.18.0)
-      activesupport (>= 4.2.0)
-      rack (>= 1.1)
-      rubocop (>= 1.33.0, < 2.0)
-    rubocop-rake (0.6.0)
-      rubocop (~> 1.0)
-    rubocop-rspec (2.19.0)
+    rubocop-rspec (2.22.0)
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
+      rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -98,8 +82,6 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     slop (3.6.0)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
     values (1.8.0)
     yard (0.9.34)
@@ -113,7 +95,7 @@ PLATFORMS
 DEPENDENCIES
   dokaz (~> 0.0.5)
   memo_wise!
-  panolint!
+  panolint-ruby!
   rake
   redcarpet (~> 3.6)
   rspec (~> 3.12)


### PR DESCRIPTION
The `panolint` repo is deprecated; `panolint-ruby` is its replacement.

Closes #308 

**Before merging:**

- [ ] ~Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR~
- [x] If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)
