### PR TITLE
Reduce production gem size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Gem enhancements:**
 
+- Reduced unzipped gem size from 173KB to 19KB [[#345](https://github.com/panorama-ed/memo_wise/pull/345)]
+
 _No breaking changes!_
 
 **Project enhancements:**

--- a/memo_wise.gemspec
+++ b/memo_wise.gemspec
@@ -26,13 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
   # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added
-  # into git.
-  spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject do |f|
-      f.match(%r{^(test|spec|features)/})
-    end
-  end
+  spec.files = Dir.glob("{CHANGELOG.md,LICENSE.txt,README.md,lib/**/*.rb}")
   spec.require_paths = ["lib"]
 
   spec.metadata = {


### PR DESCRIPTION
Hello,

please check if this makes sense and if the production gem should also include other files

---

Include only files that are needed for the production gem.

Also avoids to use git to allow to build the package in an environment
that does not have git (on purpose).

### Before

173K

```
.dokaz
.github/PULL_REQUEST_TEMPLATE.md
.github/dependabot.yml
.github/workflows/dependency-review.yml
.github/workflows/main.yml
.gitignore
.rspec
.rubocop.yml
.ruby-version
.yardopts
CHANGELOG.md
CODE_OF_CONDUCT.md
Gemfile
Gemfile.lock
LICENSE.txt
README.md
Rakefile
benchmarks/Gemfile
benchmarks/benchmarks.rb
bin/console
bin/setup
lib/memo_wise.rb
lib/memo_wise/internal_api.rb
lib/memo_wise/version.rb
logo/logo.png
memo_wise.gemspec
```

### After

19K

```
CHANGELOG.md
LICENSE.txt
README.md
lib/memo_wise.rb
lib/memo_wise/internal_api.rb
lib/memo_wise/version.rb
```

**Before merging:**

- [x] ~Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR~
- [x] If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)
