### PR TITLE
Prefer require_relative for internal requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Gem enhancements:**
 
+- Changed internal `require`s to `require_relative` to make code less dependent on the load path [[#350](https://github.com/panorama-ed/memo_wise/pull/350)]
+
 _No breaking changes!_
 
 **Project enhancements:**

--- a/lib/memo_wise.rb
+++ b/lib/memo_wise.rb
@@ -2,8 +2,8 @@
 
 require "set" # Ruby < 3.2 does not load `set` by default.
 
-require "memo_wise/internal_api"
-require "memo_wise/version"
+require_relative "memo_wise/internal_api"
+require_relative "memo_wise/version"
 
 # MemoWise is the wise choice for memoization in Ruby.
 #


### PR DESCRIPTION
As a side note, this change has been approved here by `@deivid-rodriguez` which is familiar with this issue: https://github.com/activeadmin/arbre/pull/622

---

`require_relative` is preferred over `require` for files within the same
project because it uses paths relative to the current file, making code
more portable and less dependent on the load path.

This change updates internal requires to use `require_relative` for
consistency, performance, and improved portability.

Ref:
- https://github.com/ruby/psych/pull/522
- https://github.com/ruby/logger/pull/20
- https://github.com/ruby/rdoc/pull/658
- https://github.com/panorama-ed/memo_wise/issues/349
- https://github.com/rubocop/rubocop/issues/8748

---

**Before merging:**

- [x] ~Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR~
- [x] ~If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)~
