### PR TITLE
⬆️ gem_bench v2.0.5

### DIFF
--- a/benchmarks/Gemfile
+++ b/benchmarks/Gemfile
@@ -7,7 +7,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby ">= 2.7.7"
 
 gem "benchmark-ips", "2.14.0"
-gem "gem_bench", "2.0.3"
+gem "gem_bench", "2.0.4"
 
 # NOTE: Regarding `require: false` below
 # 1. GitHub version of MemoWise and the local source of MemoWise share a namespace

--- a/benchmarks/Gemfile
+++ b/benchmarks/Gemfile
@@ -7,7 +7,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby ">= 2.7.7"
 
 gem "benchmark-ips", "2.14.0"
-gem "gem_bench", "2.0.4"
+gem "gem_bench", "2.0.5"
 
 # NOTE: Regarding `require: false` below
 # 1. GitHub version of MemoWise and the local source of MemoWise share a namespace


### PR DESCRIPTION
Fixes the `require_relative` > `require` issue discussed in #349 for the `gem_bench` gem itself.  Does not merit a mention in the changelog, IMO.

**Before merging:**

- [ ] Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR
- [x] If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)
