### PR TITLE
Configure Style/NumericPredicate for performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,3 +15,6 @@ Style/DocumentDynamicEvalDefinition:
 
 Style/MultipleComparison:
   Enabled: false
+
+Style/NumericPredicate:
+  EnforcedStyle: comparison

--- a/benchmarks/benchmarks.rb
+++ b/benchmarks/benchmarks.rb
@@ -291,7 +291,7 @@ end
     benchmark_json.sort_by! { |json| json["name"] }
 
     # Print headers based on the first benchmark_json
-    if i.zero?
+    if i == 0
       benchmark_headers = benchmark_json.map do |benchmark_gem|
         # Gem name is of the form:
         # "memoist (1.1.0): ()"

--- a/lib/memo_wise/internal_api.rb
+++ b/lib/memo_wise/internal_api.rb
@@ -44,7 +44,7 @@ module MemoWise
     #   - :double_splat (examples: `def foo(a: 1)`, `def foo(a:, **b)`)
     #   - :splat_and_double_splat (examples: `def foo(a=1, b: 2)`, `def foo(a=1, **b)`, `def foo(*a, **b)`)
     def self.method_arguments(method)
-      return NONE if method.arity.zero?
+      return NONE if method.arity == 0
 
       parameters = method.parameters.map(&:first)
 


### PR DESCRIPTION
Hello,

While the [Style/NumericPredicate](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NumericPredicate) cop recommends using `.zero?`, this can lead to performance degradation in gems where zero checks are frequent and speed-critical; for such performance-oriented libraries, using `== 0` remains preferable despite not adhering to the style guide.

This will not lead to performance improvements for the current implementation of memo_wise, I'm rather submitting this as a "reminder"

---

Replace predicate methods like `v.zero?` with direct comparison `v == 0` for better performance.

While the current implementation may not show visible improvements, frequently called methods using `.zero?` instead of `== 0` can lead to significant performance losses.

Benchmarks across Ruby versions 2.5 to 3.3 consistently show comparisons  outperforming predicates:

```
Comparison (Ruby 2.6 to 3.2, v = 0):
              v == 0: 21479329.3 i/s
             v.zero?: 17979885.4 i/s - 1.19x  (± 0.00) slower

Comparison (Ruby 2.5 and 3.3, v = 0):
              v == 0: 23652215.7 i/s
             v.zero?: 21843174.0 i/s - 1.08x  (± 0.00) slower

Comparison (Ruby 2.5 to 3.3, v = 1):
              v == 0: 23227474.2 i/s
             v.zero?: 21675200.9 i/s - 1.07x  (± 0.00) slower
```

**Before merging:**

- [ ] Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR
- [x] ~If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)~
