### PR TITLE
Bump webrick to resolve security vulnerability alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ _No breaking changes!_
 
 **Project enhancements:**
 
+- Updated `webrick` in `Gemfile.lock` to resolve CVE-2024-47220. This vulnerability does not impact `memo_wise` users.
+
 ## [v1.10.0](https://github.com/panorama-ed/memo_wise/compare/v1.9.0...v1.10.0)
 
 **Gem enhancements:**

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     slop (3.6.0)
     unicode-display_width (2.5.0)
     values (1.8.0)
-    webrick (1.8.1)
+    webrick (1.8.2)
     yard (0.9.36)
     yard-doctest (0.1.17)
       minitest


### PR DESCRIPTION
This commit bumps the `webrick` dependency to resolve CVE-2024-47220. This vulnerability is not a risk for `memo_wise` users because `webrick` is only used for development of this gem, but it's simple to update so we're doing so.

**Before merging:**

- [ ] ~Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR~
- [x] If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)
