### PR TITLE
Remove Ruby 2.5 and 2.6 support to address a rexml CVE

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use
         # quotes for '3.0' -- without quotes, CI sees '3' and runs the latest.
-        ruby: [2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, jruby, truffleruby-head]
+        ruby: [2.7, '3.0', 3.1, 3.2, 3.3, jruby, truffleruby-head]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,20 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/panorama-ed/memo_wise/compare/v1.10.0...HEAD)
 
+**Gem enhancements:** none
+
+_No breaking changes!_
+
+**Project enhancements:** none
+
+## [v1.11.0](https://github.com/panorama-ed/memo_wise/compare/v1.10.0...v1.11.0)
+
 **Gem enhancements:**
 
 - Changed internal `require`s to `require_relative` to make code less dependent on the load path [[#350](https://github.com/panorama-ed/memo_wise/pull/350)]
 
-_No breaking changes!_
+_Breaking changes:_
+- Removed Ruby 2.5 (EOL) and 2.6 (EOL) support to allow upgrading rexml dependency version from a version that includes a [CVE](https://www.ruby-lang.org/en/news/2024/10/28/redos-rexml-cve-2024-49761/) [[#362]](https://github.com/panorama-ed/memo_wise/pull/362)
 
 **Project enhancements:**
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    memo_wise (1.10.0)
+    memo_wise (1.11.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/memo_wise/version.rb
+++ b/lib/memo_wise/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MemoWise
-  VERSION = "1.10.0"
+  VERSION = "1.11.0"
 end

--- a/memo_wise.gemspec
+++ b/memo_wise.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     "marc@usainnov.com",
   ]
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
 
   # Specify which files should be added to the gem when it is released.
   spec.files = Dir.glob("{CHANGELOG.md,LICENSE.txt,README.md,lib/**/*.rb}")


### PR DESCRIPTION
**Before merging:**

- [ ] Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR
- [ ] If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)
