### PR TITLE
Document duplicated `CODECOV_TOKEN` in GitHub settings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,20 +6,6 @@ on:
   push:
     branches:
     - main
-
-  # Though GitHub's documentation mostly says you only need this for reusable
-  # workflows (i.e. workflows that call other workflows), it seems that GitHub
-  # does not pass secrets to `pull_request` events that come from forks (which
-  # it seems Dependabot's PRs do?) unless they are explicitly passed through,
-  # because they do not want a forker's PR to be able to exfiltrate secret data
-  # from the forked repo. This behavior is not really documented with respect to
-  # Dependabot but some hints are here:
-  # - https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow
-  # - https://github.com/pypa/gh-action-pypi-publish/discussions/49
-  workflow_call:
-    secrets:
-      CODECOV_TOKEN:
-        required: true
 jobs:
   ci:
     name: CI
@@ -57,6 +43,9 @@ jobs:
       with:
         files: ./coverage/coverage.xml
         fail_ci_if_error: true # optional (default = false)
+        # NOTE: If you change this secret, you must change it under the repo
+        # secrets settings for both GitHub Actions *and* Dependabot secrets. For
+        # more context, see: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true # optional (default = false)
       if: matrix.ruby == 3.3


### PR DESCRIPTION
This commit adds documentation to the fix needed to ensure that Codecov works for PRs that are both created by engineers and created by Dependabot.

---

I tested this by recreating [this Dependabot PR](https://github.com/panorama-ed/memo_wise/pull/363) after setting the secret in the repo settings and confirming that the Codecov CI step passed when previously it failed.

**Before merging:**

- [ ] ~Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR~
- [ ] ~If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)~