### PR TITLE
Undefine VERSION in gemspec to avoid namespace pollution between multiple MemoWises

### DIFF
--- a/benchmarks/benchmarks.rb
+++ b/benchmarks/benchmarks.rb
@@ -15,6 +15,9 @@ LOCAL_BENCHMARK_NAME = "memo_wise-local"
 # This means we must `require: false` in `benchmarks/Gemfile` all, or all but one, of each of these duplicates,
 #   or we take care to only load them in discrete Ruby versions,
 #   to avoid a namespace collision before re-namespacing duplicates
+# NOTE: In future Ruby versions, we can avoid the use of `GemBench` and the
+# complexity of `spec.version` in `memo_wise.gemspec` by using namespaces. For
+# more context, see: https://bugs.ruby-lang.org/issues/21311
 re_namespaced_gems = [
   GemBench::Jersey.new(
     gem_name: "memo_wise",

--- a/memo_wise.gemspec
+++ b/memo_wise.gemspec
@@ -1,13 +1,30 @@
 # frozen_string_literal: true
 
-require_relative "lib/memo_wise/version"
-
 Gem::Specification.new do |spec|
-  spec.name     = "memo_wise"
-  spec.version  = MemoWise::VERSION
-  spec.summary  = "The wise choice for Ruby memoization"
+  spec.name = "memo_wise"
+
+  # After loading the `VERSION` constant, save it to a variable to use in this
+  # gemspec and then undefine it. This allows benchmarks to compare multiple
+  # versions of MemoWise against each other without inadvertently sharing the
+  # same `VERSION` constant.
+  # NOTE: In future Ruby versions, we can avoid this complexity and the use of
+  # `GemBench` in `benchmarks.rb` by using namespaces. For more context, see:
+  # https://bugs.ruby-lang.org/issues/21311
+  # NOTE: It's important that we use `load` instead of `require_relative`
+  # because the latter only loads a file once, and so by undefining the
+  # `VERSION` constant we can make it difficult to access that value again
+  # later. For more context, see: https://github.com/panorama-ed/memo_wise/pull/370#issuecomment-2560268423
+  spec.version = Module.new.tap do |mod|
+    # NOTE: We fully qualify `Kernel` here because Rubygems defines its own
+    # `load` method, which is used by default when this code is executed by
+    # `gem build memo_wise.gemspec`. That `load` method does not support the
+    # optional "wrap" parameter we pass through as `mod`. For more context, see:
+    # https://github.com/simplecov-ruby/simplecov/issues/557#issuecomment-2630782358
+    Kernel.load("lib/memo_wise/version.rb", mod)
+  end::MemoWise::VERSION
+  spec.summary = "The wise choice for Ruby memoization"
   spec.homepage = "https://github.com/panorama-ed/memo_wise"
-  spec.license  = "MIT"
+  spec.license = "MIT"
 
   spec.authors = [
     "Panorama Education",


### PR DESCRIPTION
This commit updates `memo_wise.gemspec` to undefine the `MemoWise::VERSION` constant after it is read, as first suggested in
https://github.com/simplecov-ruby/simplecov/issues/557#issuecomment-825171399.

Before this change, accessing `MemoWise::VERSION` immediately after the `doff_and_don` call in `benchmarks.rb` gives the version of the gem pulled from GitHub, even though `doff_and_don` should mean nothing is in the `MemoWise` namespace. After this change, accessing `MemoWise::VERSION` there gives this error as we expect:

```
uninitialized constant MemoWise (NameError)
```

**Before merging:**

- [ ] ~Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR~
- [ ] ~If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)~
