### PR TITLE
Remove test exceptions for JRuby

### DIFF
--- a/spec/adding_methods_spec.rb
+++ b/spec/adding_methods_spec.rb
@@ -45,28 +45,24 @@ RSpec.describe "adding methods" do # rubocop:disable RSpec/DescribeClass
         not_to change { klass.singleton_class.private_methods.to_set }
     end
 
-    # These test cases would fail due to a JRuby bug
-    # Skipping to make build pass until the bug is fixed
-    unless RUBY_PLATFORM == "java"
-      context "when a class method is memoized" do
-        subject do
-          klass.send(:prepend, MemoWise)
-          klass.send(:memo_wise, self: :example)
-        end
+    context "when a class method is memoized" do
+      subject do
+        klass.send(:prepend, MemoWise)
+        klass.send(:memo_wise, self: :example)
+      end
 
-        let(:klass) do
-          Class.new do
-            def self.example; end
-          end
+      let(:klass) do
+        Class.new do
+          def self.example; end
         end
+      end
 
-        let(:expected_public_class_methods) { super() << :inherited }
+      let(:expected_public_class_methods) { super() << :inherited }
 
-        it "adds expected public *instance* methods only" do
-          expect { subject }.
-            to change { klass.singleton_methods.to_set }.
-            by(expected_public_class_methods)
-        end
+      it "adds expected public *instance* methods only" do
+        expect { subject }.
+          to change { klass.singleton_methods.to_set }.
+          by(expected_public_class_methods)
       end
     end
   end

--- a/spec/memo_wise/internal_api_spec.rb
+++ b/spec/memo_wise/internal_api_spec.rb
@@ -10,31 +10,26 @@ RSpec.describe MemoWise::InternalAPI do
       it { expect { subject }.to raise_error(ArgumentError) }
     end
 
-    # These test cases would fail due to a JRuby bug
-    # Skipping to make build pass until the bug is fixed
-    # https://github.com/jruby/jruby/issues/6896
-    unless RUBY_PLATFORM == "java"
-      context "when klass is a singleton class of an original class" do
-        let(:klass) { original_class.singleton_class }
+    context "when klass is a singleton class of an original class" do
+      let(:klass) { original_class.singleton_class }
 
-        context "when assigned to a constant" do
-          let(:original_class) { String }
+      context "when assigned to a constant" do
+        let(:original_class) { String }
 
-          it { is_expected.to eq(original_class) }
-        end
+        it { is_expected.to eq(original_class) }
+      end
 
-        context "when singleton class #to_s convention is not followed" do
-          include_context "with context for instance methods"
+      context "when singleton class #to_s convention is not followed" do
+        include_context "with context for instance methods"
 
-          let(:original_class) { class_with_memo }
-          let(:klass) do
-            super().tap do |sc|
-              sc.define_singleton_method(:to_s) { "not following convention" }
-            end
+        let(:original_class) { class_with_memo }
+        let(:klass) do
+          super().tap do |sc|
+            sc.define_singleton_method(:to_s) { "not following convention" }
           end
-
-          it { is_expected.to eq(original_class) }
         end
+
+        it { is_expected.to eq(original_class) }
       end
     end
   end

--- a/spec/memo_wise_spec.rb
+++ b/spec/memo_wise_spec.rb
@@ -432,105 +432,126 @@ RSpec.describe MemoWise do
       end
     end
 
-    # These test cases would fail due to a JRuby bug
-    # Skipping to make build pass until the bug is fixed
-    # https://github.com/jruby/jruby/issues/6896
-    unless RUBY_PLATFORM == "java"
-      context "with class methods" do
-        context "when defined with 'def self.'" do
-          include_context "with context for class methods via 'def self.'"
+    context "with class methods" do
+      context "when defined with 'def self.'" do
+        include_context "with context for class methods via 'def self.'"
 
-          # Use the class as the target of "#memo_wise shared examples"
-          let(:target) { class_with_memo }
+        # Use the class as the target of "#memo_wise shared examples"
+        let(:target) { class_with_memo }
 
-          it_behaves_like "#memo_wise shared examples"
+        it_behaves_like "#memo_wise shared examples"
 
-          it "creates a class-level instance variable" do
-            # NOTE: test implementation detail to ensure the inverse test is valid
-            expect(class_with_memo.instance_variables).to include(:@_memo_wise)
+        it "creates a class-level instance variable" do
+          # NOTE: test implementation detail to ensure the inverse test is valid
+          expect(class_with_memo.instance_variables).to include(:@_memo_wise)
+        end
+
+        it_behaves_like "handles memoized/non-memoized methods with the same name at different scopes" do
+          let(:memoized) { class_with_memo }
+          let(:non_memoized) { class_with_memo.new }
+          let(:non_memoized_name) { :instance }
+        end
+
+        context "when an invalid hash key is passed to .memo_wise" do
+          let(:class_with_memo) do
+            Class.new do
+              prepend MemoWise
+
+              def self.class_method; end
+            end
           end
 
-          it_behaves_like "handles memoized/non-memoized methods with the same name at different scopes" do
-            let(:memoized) { class_with_memo }
-            let(:non_memoized) { class_with_memo.new }
-            let(:non_memoized_name) { :instance }
+          it "raises an error when passing a key which is not `self:`" do
+            expect { class_with_memo.send(:memo_wise, bad_key: :class_method) }.
+              to raise_error(ArgumentError, "`:self` is the only key allowed in memo_wise")
           end
+        end
 
-          context "when an invalid hash key is passed to .memo_wise" do
-            let(:class_with_memo) do
-              Class.new do
-                prepend MemoWise
+        context "when the class has a child class" do
+          let(:child_class) do
+            Class.new(class_with_memo) do
+              def self.child_method_counter
+                @child_method_counter || 0
+              end
 
-                def self.class_method; end
+              def self.child_method
+                @child_method_counter = child_method_counter + 1
+                "child_method"
               end
             end
-
-            it "raises an error when passing a key which is not `self:`" do
-              expect { class_with_memo.send(:memo_wise, bad_key: :class_method) }.
-                to raise_error(ArgumentError, "`:self` is the only key allowed in memo_wise")
-            end
           end
 
-          context "when the class has a child class" do
-            let(:child_class) do
-              Class.new(class_with_memo) do
-                def self.child_method_counter
+          it "memoizes the parent methods" do
+            expect(Array.new(4) { child_class.no_args }).to all eq("no_args")
+            expect(child_class.no_args_counter).to eq(1)
+            expect(Array.new(4) { child_class.child_method }).to all eq("child_method")
+            expect(child_class.child_method_counter).to eq(4)
+          end
+
+          context "when the child class also memoizes methods" do
+            before :each do
+              child_class.prepend described_class
+              child_class.memo_wise self: :child_method
+            end
+
+            it "memoizes the parent and child methods separately" do
+              expect(Array.new(4) { child_class.no_args }).to all eq("no_args")
+              expect(child_class.no_args_counter).to eq(1)
+              expect(Array.new(4) { child_class.child_method }).to all eq("child_method")
+              expect(child_class.child_method_counter).to eq(1)
+            end
+          end
+        end
+      end
+
+      context "when defined with scope 'class << self'" do
+        include_context "with context for class methods via scope 'class << self'"
+
+        # Use the class as the target of "#memo_wise shared examples"
+        let(:target) { class_with_memo }
+
+        it_behaves_like "#memo_wise shared examples"
+
+        it "creates a class-level instance variable" do
+          # NOTE: this test ensure the inverse test above continues to be valid
+          expect(class_with_memo.instance_variables).to include(:@_memo_wise)
+        end
+
+        it_behaves_like "handles memoized/non-memoized methods with the same name at different scopes" do
+          let(:memoized) { class_with_memo }
+          let(:non_memoized) { class_with_memo.new }
+          let(:non_memoized_name) { :instance }
+        end
+
+        context "when the class has a child class" do
+          let(:child_class) do
+            Class.new(class_with_memo) do
+              class << self
+                def child_method_counter
                   @child_method_counter || 0
                 end
 
-                def self.child_method
+                def child_method
                   @child_method_counter = child_method_counter + 1
                   "child_method"
                 end
               end
             end
-
-            it "memoizes the parent methods" do
-              expect(Array.new(4) { child_class.no_args }).to all eq("no_args")
-              expect(child_class.no_args_counter).to eq(1)
-              expect(Array.new(4) { child_class.child_method }).to all eq("child_method")
-              expect(child_class.child_method_counter).to eq(4)
-            end
-
-            context "when the child class also memoizes methods" do
-              before :each do
-                child_class.prepend described_class
-                child_class.memo_wise self: :child_method
-              end
-
-              it "memoizes the parent and child methods separately" do
-                expect(Array.new(4) { child_class.no_args }).to all eq("no_args")
-                expect(child_class.no_args_counter).to eq(1)
-                expect(Array.new(4) { child_class.child_method }).to all eq("child_method")
-                expect(child_class.child_method_counter).to eq(1)
-              end
-            end
-          end
-        end
-
-        context "when defined with scope 'class << self'" do
-          include_context "with context for class methods via scope 'class << self'"
-
-          # Use the class as the target of "#memo_wise shared examples"
-          let(:target) { class_with_memo }
-
-          it_behaves_like "#memo_wise shared examples"
-
-          it "creates a class-level instance variable" do
-            # NOTE: this test ensure the inverse test above continues to be valid
-            expect(class_with_memo.instance_variables).to include(:@_memo_wise)
           end
 
-          it_behaves_like "handles memoized/non-memoized methods with the same name at different scopes" do
-            let(:memoized) { class_with_memo }
-            let(:non_memoized) { class_with_memo.new }
-            let(:non_memoized_name) { :instance }
+          it "memoizes the parent methods" do
+            expect(Array.new(4) { child_class.no_args }).to all eq("no_args")
+            expect(child_class.no_args_counter).to eq(1)
+            expect(Array.new(4) { child_class.child_method }).to all eq("child_method")
+            expect(child_class.child_method_counter).to eq(4)
           end
 
-          context "when the class has a child class" do
+          context "when the child class also memoizes methods" do
             let(:child_class) do
               Class.new(class_with_memo) do
                 class << self
+                  prepend MemoWise
+
                   def child_method_counter
                     @child_method_counter || 0
                   end
@@ -539,132 +560,101 @@ RSpec.describe MemoWise do
                     @child_method_counter = child_method_counter + 1
                     "child_method"
                   end
+                  memo_wise :child_method
                 end
               end
             end
 
-            it "memoizes the parent methods" do
+            it "memoizes the parent and child methods separately" do
               expect(Array.new(4) { child_class.no_args }).to all eq("no_args")
               expect(child_class.no_args_counter).to eq(1)
               expect(Array.new(4) { child_class.child_method }).to all eq("child_method")
-              expect(child_class.child_method_counter).to eq(4)
-            end
-
-            context "when the child class also memoizes methods" do
-              let(:child_class) do
-                Class.new(class_with_memo) do
-                  class << self
-                    prepend MemoWise
-
-                    def child_method_counter
-                      @child_method_counter || 0
-                    end
-
-                    def child_method
-                      @child_method_counter = child_method_counter + 1
-                      "child_method"
-                    end
-                    memo_wise :child_method
-                  end
-                end
-              end
-
-              it "memoizes the parent and child methods separately" do
-                expect(Array.new(4) { child_class.no_args }).to all eq("no_args")
-                expect(child_class.no_args_counter).to eq(1)
-                expect(Array.new(4) { child_class.child_method }).to all eq("child_method")
-                expect(child_class.child_method_counter).to eq(1)
-              end
+              expect(child_class.child_method_counter).to eq(1)
             end
           end
         end
       end
     end
 
-    # These test cases would fail due to a JRuby bug
-    # Skipping to make build pass until the bug is fixed
-    # https://github.com/jruby/jruby/issues/6896
-    unless RUBY_PLATFORM == "java"
-      context "with module methods" do
-        context "when defined with 'def self.'" do
-          include_context "with context for module methods via 'def self.'"
+    context "with module methods" do
+      context "when defined with 'def self.'" do
+        include_context "with context for module methods via 'def self.'"
 
-          # Use the module as the target of "#memo_wise shared examples"
-          let(:target) { module_with_memo }
+        # Use the module as the target of "#memo_wise shared examples"
+        let(:target) { module_with_memo }
 
-          it_behaves_like "#memo_wise shared examples"
+        it_behaves_like "#memo_wise shared examples"
 
-          it "creates a module-level instance variable" do
-            # NOTE: test implementation detail to ensure the inverse test is valid
-            expect(module_with_memo.instance_variables).to include(:@_memo_wise)
-          end
-
-          context "when an invalid hash key is passed to .memo_wise" do
-            let(:module_with_memo) do
-              Module.new do
-                prepend MemoWise
-
-                def self.module_method; end
-              end
-            end
-
-            it "raises an error when passing a key which is not `self:`" do
-              expect { module_with_memo.send(:memo_wise, bad_key: :module_method) }.
-                to raise_error(ArgumentError, "`:self` is the only key allowed in memo_wise")
-            end
-          end
+        it "creates a module-level instance variable" do
+          # NOTE: test implementation detail to ensure the inverse test is valid
+          expect(module_with_memo.instance_variables).to include(:@_memo_wise)
         end
 
-        context "when defined with scope 'module << self'" do
-          include_context "with context for module methods via scope 'class << self'"
+        context "when an invalid hash key is passed to .memo_wise" do
+          let(:module_with_memo) do
+            Module.new do
+              prepend MemoWise
 
-          # Use the module as the target of "#memo_wise shared examples"
-          let(:target) { module_with_memo }
+              def self.module_method; end
+            end
+          end
 
-          it_behaves_like "#memo_wise shared examples"
-
-          it "creates a module-level instance variable" do
-            # NOTE: this test ensure the inverse test above continues to be valid
-            expect(module_with_memo.instance_variables).to include(:@_memo_wise)
+          it "raises an error when passing a key which is not `self:`" do
+            expect { module_with_memo.send(:memo_wise, bad_key: :module_method) }.
+              to raise_error(ArgumentError, "`:self` is the only key allowed in memo_wise")
           end
         end
       end
 
-      context "when a class inherits from a parent class whose extended module memoizes methods" do
-        let(:parent_class) do
-          Class.new do
-            extend Module1
+      context "when defined with scope 'module << self'" do
+        include_context "with context for module methods via scope 'class << self'"
+
+        # Use the module as the target of "#memo_wise shared examples"
+        let(:target) { module_with_memo }
+
+        it_behaves_like "#memo_wise shared examples"
+
+        it "creates a module-level instance variable" do
+          # NOTE: this test ensure the inverse test above continues to be valid
+          expect(module_with_memo.instance_variables).to include(:@_memo_wise)
+        end
+      end
+    end
+
+    context "when a class inherits from a parent class whose extended module memoizes methods" do
+      let(:parent_class) do
+        Class.new do
+          extend Module1
+        end
+      end
+
+      let(:module1) do
+        Module.new do
+          prepend MemoWise
+
+          def module1_method_counter
+            @module1_method_counter || 0 # rubocop:disable RSpec/InstanceVariable
           end
-        end
 
-        let(:module1) do
-          Module.new do
-            prepend MemoWise
-
-            def module1_method_counter
-              @module1_method_counter || 0 # rubocop:disable RSpec/InstanceVariable
-            end
-
-            def module1_method
-              @module1_method_counter = module1_method_counter + 1
-              "module1_method"
-            end
-            memo_wise :module1_method
+          def module1_method
+            @module1_method_counter = module1_method_counter + 1
+            "module1_method"
           end
+          memo_wise :module1_method
         end
+      end
 
-        let(:child_class) do
-          Class.new(parent_class)
-        end
+      let(:child_class) do
+        Class.new(parent_class)
+      end
 
-        before(:each) do
-          stub_const("Module1", module1)
-        end
+      before(:each) do
+        stub_const("Module1", module1)
+      end
 
-        it "memoizes inherited methods separately" do
-          expect(Array.new(4) { child_class.module1_method }).to all eq("module1_method")
-          expect(child_class.module1_method_counter).to eq(1)
-        end
+      it "memoizes inherited methods separately" do
+        expect(Array.new(4) { child_class.module1_method }).to all eq("module1_method")
+        expect(child_class.module1_method_counter).to eq(1)
       end
     end
 
@@ -751,42 +741,38 @@ RSpec.describe MemoWise do
           end
         end
 
-        # These test cases would fail due to a JRuby bug
-        # Skipping to make build pass until the bug is fixed
-        unless RUBY_PLATFORM == "java"
-          context "when defined with 'def self.' and 'def'" do
-            let(:module_with_memo) do
-              Module.new do
-                prepend MemoWise
+        context "when defined with 'def self.' and 'def'" do
+          let(:module_with_memo) do
+            Module.new do
+              prepend MemoWise
 
-                def self.test_method
-                  Random.rand
-                end
-                memo_wise self: :test_method
-
-                def test_method
-                  Random.rand
-                end
-                memo_wise :test_method
+              def self.test_method
+                Random.rand
               end
-            end
-            let(:class_including_module_with_memo) do
-              Class.new do
-                include ModuleWithMemo
-              end
-            end
-            let(:instance) { class_including_module_with_memo.new }
+              memo_wise self: :test_method
 
-            before(:each) do
-              stub_const("ModuleWithMemo", module_with_memo)
-            end
-
-            it "memoizes instance and singleton methods separately" do
-              aggregate_failures do
-                expect(instance.test_method).to eq(instance.test_method) # rubocop:disable RSpec/IdenticalEqualityAssertion
-                expect(module_with_memo.test_method).to eq(module_with_memo.test_method) # rubocop:disable RSpec/IdenticalEqualityAssertion
-                expect(instance.test_method).to_not eq(module_with_memo.test_method)
+              def test_method
+                Random.rand
               end
+              memo_wise :test_method
+            end
+          end
+          let(:class_including_module_with_memo) do
+            Class.new do
+              include ModuleWithMemo
+            end
+          end
+          let(:instance) { class_including_module_with_memo.new }
+
+          before(:each) do
+            stub_const("ModuleWithMemo", module_with_memo)
+          end
+
+          it "memoizes instance and singleton methods separately" do
+            aggregate_failures do
+              expect(instance.test_method).to eq(instance.test_method) # rubocop:disable RSpec/IdenticalEqualityAssertion
+              expect(module_with_memo.test_method).to eq(module_with_memo.test_method) # rubocop:disable RSpec/IdenticalEqualityAssertion
+              expect(instance.test_method).to_not eq(module_with_memo.test_method)
             end
           end
         end

--- a/spec/reset_memo_wise_spec.rb
+++ b/spec/reset_memo_wise_spec.rb
@@ -390,10 +390,67 @@ RSpec.describe MemoWise do
         end
       end
 
-      # These test cases would fail due to a JRuby bug
-      # Skipping to make build pass until the bug is fixed
-      unless RUBY_PLATFORM == "java"
-        context "when method name is the same as a memoized class method" do
+      context "when method name is the same as a memoized class method" do
+        let(:class_with_memo) do
+          Class.new do
+            prepend MemoWise
+
+            def instance_one_arg_counter
+              @instance_one_arg_counter || 0
+            end
+
+            def one_arg(a) # rubocop:disable Naming/MethodParameterName
+              @instance_one_arg_counter = instance_one_arg_counter + 1
+              "instance_one_arg: a=#{a}"
+            end
+            memo_wise :one_arg
+
+            def self.class_one_arg_counter
+              @class_one_arg_counter || 0
+            end
+
+            def self.one_arg(a) # rubocop:disable Naming/MethodParameterName
+              @class_one_arg_counter = class_one_arg_counter + 1
+              "class_one_arg: a=#{a}"
+            end
+            memo_wise self: :one_arg
+          end
+        end
+
+        it "resets memoization independently" do
+          instance = class_with_memo.new
+          expect(Array.new(4) { instance.one_arg(1) }).to all eq("instance_one_arg: a=1")
+          expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
+
+          class_with_memo.reset_memo_wise(:one_arg)
+
+          expect(Array.new(4) { instance.one_arg(1) }).to all eq("instance_one_arg: a=1")
+          expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
+
+          expect(instance.instance_one_arg_counter).to eq 1 # Never reset, so only incremented once.
+          expect(class_with_memo.class_one_arg_counter).to eq 2 # Once initially and once after resetting.
+
+          instance.reset_memo_wise(:one_arg)
+
+          expect(Array.new(4) { instance.one_arg(1) }).to all eq("instance_one_arg: a=1")
+          expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
+
+          expect(instance.instance_one_arg_counter).to eq 2 # Once initially and once after resetting.
+          expect(class_with_memo.class_one_arg_counter).to eq 2 # Once initially and once after resetting.
+        end
+      end
+    end
+
+    context "with class methods" do
+      context "when defined with 'def self.'" do
+        include_context "with context for class methods via 'def self.'"
+
+        # Use the class as the target of "#reset_memo_wise shared examples"
+        let(:target) { class_with_memo }
+
+        it_behaves_like "#reset_memo_wise shared examples"
+
+        context "when method name is the same as a memoized instance method" do
           let(:class_with_memo) do
             Class.new do
               prepend MemoWise
@@ -443,132 +500,66 @@ RSpec.describe MemoWise do
           end
         end
       end
-    end
 
-    # These test cases would fail due to a JRuby bug
-    # Skipping to make build pass until the bug is fixed
-    # https://github.com/jruby/jruby/issues/6896
-    unless RUBY_PLATFORM == "java"
-      context "with class methods" do
-        context "when defined with 'def self.'" do
-          include_context "with context for class methods via 'def self.'"
+      context "when defined with scope 'class << self'" do
+        include_context "with context for class methods via scope 'class << self'"
 
-          # Use the class as the target of "#reset_memo_wise shared examples"
-          let(:target) { class_with_memo }
+        # Use the class as the target of "#reset_memo_wise shared examples"
+        let(:target) { class_with_memo }
 
-          it_behaves_like "#reset_memo_wise shared examples"
+        it_behaves_like "#reset_memo_wise shared examples"
 
-          context "when method name is the same as a memoized instance method" do
-            let(:class_with_memo) do
-              Class.new do
+        context "when method name is the same as a memoized instance method" do
+          let(:class_with_memo) do
+            Class.new do
+              prepend MemoWise
+
+              def instance_one_arg_counter
+                @instance_one_arg_counter || 0
+              end
+
+              def one_arg(a) # rubocop:disable Naming/MethodParameterName
+                @instance_one_arg_counter = instance_one_arg_counter + 1
+                "instance_one_arg: a=#{a}"
+              end
+              memo_wise :one_arg
+
+              class << self
                 prepend MemoWise
 
-                def instance_one_arg_counter
-                  @instance_one_arg_counter || 0
-                end
-
-                def one_arg(a) # rubocop:disable Naming/MethodParameterName
-                  @instance_one_arg_counter = instance_one_arg_counter + 1
-                  "instance_one_arg: a=#{a}"
-                end
-                memo_wise :one_arg
-
-                def self.class_one_arg_counter
+                def class_one_arg_counter
                   @class_one_arg_counter || 0
                 end
 
-                def self.one_arg(a) # rubocop:disable Naming/MethodParameterName
+                def one_arg(a) # rubocop:disable Naming/MethodParameterName
                   @class_one_arg_counter = class_one_arg_counter + 1
                   "class_one_arg: a=#{a}"
                 end
-                memo_wise self: :one_arg
+                memo_wise :one_arg
               end
-            end
-
-            it "resets memoization independently" do
-              instance = class_with_memo.new
-              expect(Array.new(4) { instance.one_arg(1) }).to all eq("instance_one_arg: a=1")
-              expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
-
-              class_with_memo.reset_memo_wise(:one_arg)
-
-              expect(Array.new(4) { instance.one_arg(1) }).to all eq("instance_one_arg: a=1")
-              expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
-
-              expect(instance.instance_one_arg_counter).to eq 1 # Never reset, so only incremented once.
-              expect(class_with_memo.class_one_arg_counter).to eq 2 # Once initially and once after resetting.
-
-              instance.reset_memo_wise(:one_arg)
-
-              expect(Array.new(4) { instance.one_arg(1) }).to all eq("instance_one_arg: a=1")
-              expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
-
-              expect(instance.instance_one_arg_counter).to eq 2 # Once initially and once after resetting.
-              expect(class_with_memo.class_one_arg_counter).to eq 2 # Once initially and once after resetting.
             end
           end
-        end
 
-        context "when defined with scope 'class << self'" do
-          include_context "with context for class methods via scope 'class << self'"
+          it "resets memoization independently" do
+            instance = class_with_memo.new
+            expect(Array.new(4) { instance.one_arg(1) }).to all eq("instance_one_arg: a=1")
+            expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
 
-          # Use the class as the target of "#reset_memo_wise shared examples"
-          let(:target) { class_with_memo }
+            class_with_memo.reset_memo_wise(:one_arg)
 
-          it_behaves_like "#reset_memo_wise shared examples"
+            expect(Array.new(4) { instance.one_arg(1) }).to all eq("instance_one_arg: a=1")
+            expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
 
-          context "when method name is the same as a memoized instance method" do
-            let(:class_with_memo) do
-              Class.new do
-                prepend MemoWise
+            expect(instance.instance_one_arg_counter).to eq 1 # Never reset, so only incremented once.
+            expect(class_with_memo.class_one_arg_counter).to eq 2 # Once initially and once after resetting.
 
-                def instance_one_arg_counter
-                  @instance_one_arg_counter || 0
-                end
+            instance.reset_memo_wise(:one_arg)
 
-                def one_arg(a) # rubocop:disable Naming/MethodParameterName
-                  @instance_one_arg_counter = instance_one_arg_counter + 1
-                  "instance_one_arg: a=#{a}"
-                end
-                memo_wise :one_arg
+            expect(Array.new(4) { instance.one_arg(1) }).to all eq("instance_one_arg: a=1")
+            expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
 
-                class << self
-                  prepend MemoWise
-
-                  def class_one_arg_counter
-                    @class_one_arg_counter || 0
-                  end
-
-                  def one_arg(a) # rubocop:disable Naming/MethodParameterName
-                    @class_one_arg_counter = class_one_arg_counter + 1
-                    "class_one_arg: a=#{a}"
-                  end
-                  memo_wise :one_arg
-                end
-              end
-            end
-
-            it "resets memoization independently" do
-              instance = class_with_memo.new
-              expect(Array.new(4) { instance.one_arg(1) }).to all eq("instance_one_arg: a=1")
-              expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
-
-              class_with_memo.reset_memo_wise(:one_arg)
-
-              expect(Array.new(4) { instance.one_arg(1) }).to all eq("instance_one_arg: a=1")
-              expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
-
-              expect(instance.instance_one_arg_counter).to eq 1 # Never reset, so only incremented once.
-              expect(class_with_memo.class_one_arg_counter).to eq 2 # Once initially and once after resetting.
-
-              instance.reset_memo_wise(:one_arg)
-
-              expect(Array.new(4) { instance.one_arg(1) }).to all eq("instance_one_arg: a=1")
-              expect(Array.new(4) { class_with_memo.one_arg(1) }).to all eq("class_one_arg: a=1")
-
-              expect(instance.instance_one_arg_counter).to eq 2 # Once initially and once after resetting.
-              expect(class_with_memo.class_one_arg_counter).to eq 2 # Once initially and once after resetting.
-            end
+            expect(instance.instance_one_arg_counter).to eq 2 # Once initially and once after resetting.
+            expect(class_with_memo.class_one_arg_counter).to eq 2 # Once initially and once after resetting.
           end
         end
       end


### PR DESCRIPTION
## Commit 1: Remove test exceptions for JRuby

This commit removes conditionals that were preventing certain tests from executing in JRuby due to JRuby bugs. Based on the comment history they seem to be mostly or entirely due to https://github.com/jruby/jruby/issues/6896 which has been resolved.

**Before merging:**

- [ ] Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR
- [ ] If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)
