### PR TITLE
Bump version to v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ follows a format inspired by [Keep a Changelog](https://keepachangelog.com/en/1.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/panorama-ed/memo_wise/compare/v1.12.0...HEAD)
+## [Unreleased](https://github.com/panorama-ed/memo_wise/compare/v1.13.0...HEAD)
+
+**Gem enhancements:** none
+
+_No breaking changes!_
+
+**Project enhancements:** none
+
+## [v1.13.0](https://github.com/panorama-ed/memo_wise/compare/v1.12.0...v1.13.0)
 
 **Gem enhancements:**
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    memo_wise (1.12.0)
+    memo_wise (1.13.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -265,14 +265,7 @@ the [code of conduct](https://github.com/panorama-ed/memo_wise/blob/main/CODE_OF
 ## Releasing
 
 To make a new release of `MemoWise` to
-[RubyGems](https://rubygems.org/gems/memo_wise), first install the `release`
-dependencies (e.g. `rake`) as follows:
-
-```shell
-BUNDLE_WITH=release bundle install
-```
-
-Then carry out these steps:
+[RubyGems](https://rubygems.org/gems/memo_wise):
 
 1. Update `CHANGELOG.md`:
    - Add an entry for the upcoming version _x.y.z_
@@ -292,7 +285,7 @@ Then carry out these steps:
    - Run `bundle install` to update `Gemfile.lock`
    - Commit with title `Bump version to x.y.z`
 
-3. `bundle exec rake release`
+3. `BUNDLE_WITH=release bundle install && BUNDLE_WITH=release bundle exec rake release`
 
 ## License
 

--- a/lib/memo_wise/version.rb
+++ b/lib/memo_wise/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MemoWise
-  VERSION = "1.12.0"
+  VERSION = "1.13.0"
 end


### PR DESCRIPTION
This commit also slightly tweaks the release instructions in `README.md` to reflect the steps I've been following for releasing new gem versions.

**Before merging:**

- [ ] ~Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR~
- [x] If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)
