### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,7 @@
 name: Main
+permissions:
+  contents: read
+  statuses: write
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/panorama-ed/memo_wise/security/code-scanning/1](https://github.com/panorama-ed/memo_wise/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's operations, the following permissions are likely sufficient:
- `contents: read` for accessing repository contents.
- `statuses: write` for updating commit statuses (if applicable).
- `id-token: write` for authentication (if required by any action).

We will analyze the workflow steps to ensure no unnecessary permissions are granted. If any step requires additional permissions (e.g., `contents: write` for uploading coverage reports), we will add them specifically.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
