### PR TITLE
Fix loading gem specification externally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/panorama-ed/memo_wise/compare/v1.13.0...HEAD)
 
-**Gem enhancements:** none
+**Gem enhancements:**
+
+- Fixed issue with external tools loading `memo_wise.gemspec` from different directories [[#397]](https://github.com/panorama-ed/memo_wise/pull/397))
 
 _No breaking changes!_
 

--- a/memo_wise.gemspec
+++ b/memo_wise.gemspec
@@ -14,14 +14,12 @@ Gem::Specification.new do |spec|
   # because the latter only loads a file once, and so by undefining the
   # `VERSION` constant we can make it difficult to access that value again
   # later. For more context, see: https://github.com/panorama-ed/memo_wise/pull/370#issuecomment-2560268423
-  spec.version = Module.new.tap do |mod|
-    # NOTE: We fully qualify `Kernel` here because Rubygems defines its own
-    # `load` method, which is used by default when this code is executed by
-    # `gem build memo_wise.gemspec`. That `load` method does not support the
-    # optional "wrap" parameter we pass through as `mod`. For more context, see:
-    # https://github.com/simplecov-ruby/simplecov/issues/557#issuecomment-2630782358
-    Kernel.load("lib/memo_wise/version.rb", mod)
-  end::MemoWise::VERSION
+  # NOTE: We fully qualify `Kernel` here because Rubygems defines its own
+  # `load` method, which is used by default when this code is executed by
+  # `gem build memo_wise.gemspec`. That `load` method does not support the
+  # optional "wrap" parameter we pass through as `mod`. For more context, see:
+  # https://github.com/simplecov-ruby/simplecov/issues/557#issuecomment-2630782358
+  spec.version = Module.new.tap { |mod| Kernel.load("#{__dir__}/lib/memo_wise/version.rb", mod) }::MemoWise::VERSION
   spec.summary = "The wise choice for Ruby memoization"
   spec.homepage = "https://github.com/panorama-ed/memo_wise"
   spec.license = "MIT"


### PR DESCRIPTION
When a gem's specification is loaded by another gem, to get at the metadata, or other info, the pathing for loading the `version.rb` won't work properly. This isn't an issue when running the gem on its own, but other tools that do analysis of other libraries will not be able to load this gemspec. Fortunately the fix is very simple, just prefix `#{__dir__}/`, and `__dir__` was introduced in Ruby 1.9.1, so shouldn't pose a problem.

I discovered this as I am now building a gem that loads other gem's gemspecs to get the data, with the goal of helping them fund-raise. https://github.com/galtzo-floss/floss_funding

**Before merging:**

- [ ] ~Copy the table printed at the end of the latest benchmark results into the `README.md` and update this PR~
- [ ] If this change merits an update to `CHANGELOG.md`, add an entry following Keep a Changelog [guidelines](https://keepachangelog.com/en/1.0.0/) with [semantic versioning](https://semver.org/)
